### PR TITLE
Add USB adaptive support to STLP

### DIFF
--- a/applications/stlp/src/app_conf.h
+++ b/applications/stlp/src/app_conf.h
@@ -13,6 +13,7 @@
 #define appconfSPI_AUDIO_PORT          5
 #define appconfWW_SAMPLES_PORT         6
 #define appconfAUDIOPIPELINE_PORT      7
+#define appconfI2S_OUTPUT_SLAVE_PORT   8
 
 /* Application tile specifiers */
 #include "platform/driver_instances.h"
@@ -26,12 +27,6 @@
 #define appconfAUDIO_PIPELINE_CHANNELS          MIC_ARRAY_CONFIG_MIC_COUNT
 /* If in channel sample format, appconfAUDIO_PIPELINE_FRAME_ADVANCE == MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME*/
 #define appconfAUDIO_PIPELINE_FRAME_ADVANCE     MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME
-
-/**
- * A positive delay will delay mics
- * A negative delay will delay ref
- */
-#define appconfINPUT_SAMPLES_MIC_DELAY_MS        0
 
 #define appconfAUDIO_PIPELINE_SKIP_STATIC_DELAY  0
 #define appconfAUDIO_PIPELINE_SKIP_AEC           0
@@ -81,9 +76,6 @@
 #endif
 
 #ifndef appconfEXTERNAL_MCLK
-#if XK_VOICE_L71 && appconfI2C_CTRL_ENABLED
-#define appconfEXTERNAL_MCLK       1
-#else
 #define appconfEXTERNAL_MCLK       0
 #endif
 #endif
@@ -106,13 +98,13 @@
 #define appconfAEC_REF_USB         0
 #define appconfAEC_REF_I2S         1
 #ifndef appconfAEC_REF_DEFAULT
-#define appconfAEC_REF_DEFAULT     appconfAEC_REF_USB
+#define appconfAEC_REF_DEFAULT     appconfAEC_REF_I2S
 #endif
 
 #define appconfMIC_SRC_MICS        0
 #define appconfMIC_SRC_USB         1
 #ifndef appconfMIC_SRC_DEFAULT
-#define appconfMIC_SRC_DEFAULT     appconfMIC_SRC_USB
+#define appconfMIC_SRC_DEFAULT     appconfMIC_SRC_MICS
 #endif
 
 #define appconfUSB_AUDIO_RELEASE   0
@@ -147,10 +139,10 @@
 /* I/O and interrupt cores for Tile 1 */
 #define appconfPDM_MIC_IO_CORE                  1 /* Must be kept off core 0 with the RTOS tick ISR */
 #define appconfI2S_IO_CORE                      2 /* Must be kept off core 0 with the RTOS tick ISR */
-#define appconfI2C_IO_CORE                      3 /* Must be kept off core 0 with the RTOS tick ISR */
+#define appconfI2C_IO_CORE                      5 /* Must be kept off core 0 with the RTOS tick ISR */
 #define appconfPDM_MIC_INTERRUPT_CORE           4 /* Must be kept off I/O cores. Best kept off core 0 with the tick ISR. */
 #define appconfI2S_INTERRUPT_CORE               5 /* Must be kept off I/O cores. Best kept off core 0 with the tick ISR. */
-#define appconfI2C_INTERRUPT_CORE               0 /* Must be kept off I/O cores. */
+#define appconfI2C_INTERRUPT_CORE               4 /* Must be kept off I/O cores. */
 
 /* Task Priorities */
 #define appconfSTARTUP_TASK_PRIORITY              (configMAX_PRIORITIES/2 + 5)

--- a/applications/stlp/src/app_conf.h
+++ b/applications/stlp/src/app_conf.h
@@ -109,7 +109,7 @@
 #define appconfUSB_AUDIO_RELEASE   0
 #define appconfUSB_AUDIO_TESTING   1
 #ifndef appconfUSB_AUDIO_MODE
-#define appconfUSB_AUDIO_MODE      appconfUSB_AUDIO_TESTING
+#define appconfUSB_AUDIO_MODE      appconfUSB_AUDIO_RELEASE
 #endif
 
 #define appconfSPI_AUDIO_RELEASE   0

--- a/applications/stlp/src/app_conf.h
+++ b/applications/stlp/src/app_conf.h
@@ -13,7 +13,6 @@
 #define appconfSPI_AUDIO_PORT          5
 #define appconfWW_SAMPLES_PORT         6
 #define appconfAUDIOPIPELINE_PORT      7
-#define appconfI2S_OUTPUT_SLAVE_PORT   8
 
 /* Application tile specifiers */
 #include "platform/driver_instances.h"
@@ -28,6 +27,12 @@
 /* If in channel sample format, appconfAUDIO_PIPELINE_FRAME_ADVANCE == MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME*/
 #define appconfAUDIO_PIPELINE_FRAME_ADVANCE     MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME
 
+/**
+ * A positive delay will delay mics
+ * A negative delay will delay ref
+ */
+#define appconfINPUT_SAMPLES_MIC_DELAY_MS        0
+
 #define appconfAUDIO_PIPELINE_SKIP_STATIC_DELAY  0
 #define appconfAUDIO_PIPELINE_SKIP_AEC           0
 #define appconfAUDIO_PIPELINE_SKIP_IC_AND_VAD    0
@@ -39,7 +44,7 @@
 #endif
 
 #ifndef appconfUSB_ENABLED
-#define appconfUSB_ENABLED         0
+#define appconfUSB_ENABLED         1
 #endif
 
 #ifndef appconfWW_ENABLED
@@ -76,7 +81,11 @@
 #endif
 
 #ifndef appconfEXTERNAL_MCLK
+#if XK_VOICE_L71 && appconfI2C_CTRL_ENABLED
+#define appconfEXTERNAL_MCLK       1
+#else
 #define appconfEXTERNAL_MCLK       0
+#endif
 #endif
 
 /*
@@ -97,19 +106,19 @@
 #define appconfAEC_REF_USB         0
 #define appconfAEC_REF_I2S         1
 #ifndef appconfAEC_REF_DEFAULT
-#define appconfAEC_REF_DEFAULT     appconfAEC_REF_I2S
+#define appconfAEC_REF_DEFAULT     appconfAEC_REF_USB
 #endif
 
 #define appconfMIC_SRC_MICS        0
 #define appconfMIC_SRC_USB         1
 #ifndef appconfMIC_SRC_DEFAULT
-#define appconfMIC_SRC_DEFAULT     appconfMIC_SRC_MICS
+#define appconfMIC_SRC_DEFAULT     appconfMIC_SRC_USB
 #endif
 
 #define appconfUSB_AUDIO_RELEASE   0
 #define appconfUSB_AUDIO_TESTING   1
 #ifndef appconfUSB_AUDIO_MODE
-#define appconfUSB_AUDIO_MODE      appconfUSB_AUDIO_RELEASE
+#define appconfUSB_AUDIO_MODE      appconfUSB_AUDIO_TESTING
 #endif
 
 #define appconfSPI_AUDIO_RELEASE   0
@@ -138,10 +147,10 @@
 /* I/O and interrupt cores for Tile 1 */
 #define appconfPDM_MIC_IO_CORE                  1 /* Must be kept off core 0 with the RTOS tick ISR */
 #define appconfI2S_IO_CORE                      2 /* Must be kept off core 0 with the RTOS tick ISR */
-#define appconfI2C_IO_CORE                      5 /* Must be kept off core 0 with the RTOS tick ISR */
+#define appconfI2C_IO_CORE                      3 /* Must be kept off core 0 with the RTOS tick ISR */
 #define appconfPDM_MIC_INTERRUPT_CORE           4 /* Must be kept off I/O cores. Best kept off core 0 with the tick ISR. */
 #define appconfI2S_INTERRUPT_CORE               5 /* Must be kept off I/O cores. Best kept off core 0 with the tick ISR. */
-#define appconfI2C_INTERRUPT_CORE               4 /* Must be kept off I/O cores. */
+#define appconfI2C_INTERRUPT_CORE               0 /* Must be kept off I/O cores. */
 
 /* Task Priorities */
 #define appconfSTARTUP_TASK_PRIORITY              (configMAX_PRIORITIES/2 + 5)

--- a/applications/stlp/src/app_conf.h
+++ b/applications/stlp/src/app_conf.h
@@ -78,7 +78,6 @@
 #ifndef appconfEXTERNAL_MCLK
 #define appconfEXTERNAL_MCLK       0
 #endif
-#endif
 
 /*
  * This option sends all 6 16 KHz channels (two channels of processed audio,

--- a/applications/stlp/src/app_conf.h
+++ b/applications/stlp/src/app_conf.h
@@ -39,7 +39,7 @@
 #endif
 
 #ifndef appconfUSB_ENABLED
-#define appconfUSB_ENABLED         1
+#define appconfUSB_ENABLED         0
 #endif
 
 #ifndef appconfWW_ENABLED

--- a/applications/stlp/src/usb/adaptive_rate_adjust.c
+++ b/applications/stlp/src/usb/adaptive_rate_adjust.c
@@ -1,9 +1,14 @@
-// Copyright 2021 XMOS LIMITED.
+// Copyright 2021 - 2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define DEBUG_UNIT ADAPTIVE_USB
+#define DEBUG_PRINT_ENABLE_ADAPTIVE_USB 1
+
+// Taken from usb_descriptors.c
+#define USB_AUDIO_EP 0x01
 
 #include "adaptive_rate_adjust.h"
+#include "adaptive_rate_callback.h"
 
 #include <stdbool.h>
 #include <xcore/port.h>
@@ -15,16 +20,6 @@
 #include <rtos_interrupt.h>
 
 #include "platform/app_pll_ctrl.h"
-
-int32_t dsp_math_multiply( int32_t input1_value, int32_t input2_value, int32_t q_format )
-{
-    int32_t ah; uint32_t al;
-    int32_t result;
-    // For rounding, accumulator is pre-loaded (1<<(q_format-1))
-    asm("maccs %0,%1,%2,%3":"=r"(ah),"=r"(al):"r"(input1_value),"r"(input2_value),"0"(0),"1"(1<<(q_format-1)));
-    asm("lextract %0,%1,%2,%3,32":"=r"(result):"r"(ah),"r"(al),"r"(q_format));
-    return result;
-}
 
 #if XK_VOICE_L71
 #define PORT_MCLK       PORT_MCLK_IN_OUT
@@ -38,185 +33,68 @@ int32_t dsp_math_multiply( int32_t input1_value, int32_t input2_value, int32_t q
 #endif
 #endif
 
-/*
- * TODO:
- * Technically, this is implementing synchronous mode, not adaptive mode.
- * If the number of audio frames sent per USB frame time is guaranteed to
- * always be the same (16 or 48) then the two modes are indistinguishable.
- * But if this is not the case (eg. occasionally receive 15 or 49) then
- * this method will not work to properly implement adaptive mode.
- *
- * If this function had visibility into the actual data rates then maybe
- * this can be solved here. Otherwise it may need to be moved into
- * tud_audio_rx_done_post_read_cb() or usb_audio_out_task(). These run
- * at a lower frequency though so would not be ideal.
- */
-
-/*
- * Setting this non-zero initializes the appPLL numerator
- * to 0 to allow the PID controller's step response to be
- * viewed via xscope.
- */
-#define PID_TEST 0
-
-/*
- * 125 microseconds between each SOF at USB high speed.
- */
-#define SOF_DELTA_TIME_US 125
-
-/*
- * If the time between SOFs is off by more than
- * this, then reset the controller's error state.
- */
-#define SOF_VALID_MAX_ERROR 0.05
-
-/*
- * If the time between SOFs is off by more than
- * this, then assume it came in a little late or early
- * due to the interrupt being delayed or USB bus traffic,
- * and do not update the PID's output, but continue to
- * integrate the error.
- */
-#define SOF_ON_TIME_MAX_ERROR 0.003
-
-#define REFERENCE_CLOCK_TICKS_PER_MICROSECOND 100
-#define US_TO_TICKS(us) (us * REFERENCE_CLOCK_TICKS_PER_MICROSECOND)
-
-#define SOF_DELTA_TIME_NOMINAL US_TO_TICKS(SOF_DELTA_TIME_US)
-#define SOF_DELTA_TIME_VALID_LOWER ((1.0 - SOF_VALID_MAX_ERROR) * SOF_DELTA_TIME_NOMINAL)
-#define SOF_DELTA_TIME_VALID_UPPER ((1.0 + SOF_VALID_MAX_ERROR) * SOF_DELTA_TIME_NOMINAL)
-#define SOF_DELTA_TIME_ON_TIME_LOWER ((1.0 - SOF_ON_TIME_MAX_ERROR) * SOF_DELTA_TIME_NOMINAL)
-#define SOF_DELTA_TIME_ON_TIME_UPPER ((1.0 + SOF_ON_TIME_MAX_ERROR) * SOF_DELTA_TIME_NOMINAL)
-
-/*
- * The ideal number of appPLL cycles between each SOF that
- * the PID controller is aiming for.
- */
-#define DELTA_CYCLES_TARGET (((appconfAUDIO_CLOCK_FREQUENCY / 10) * SOF_DELTA_TIME_US) / 100000)
-
-/*
- * The number of fractional bits in the fixed point
- * numbers used by the PID controller.
- */
-#define P 16
-
-__attribute__((dual_issue))
-void sof_cb(void)
-{
-    static int32_t numerator = PID_TEST ? 0 : Q(P)((APP_PLL_FRAC_NOM & 0x0000FF00) >> 8);
-    static int32_t previous_error;
-    static int32_t integral;
-
-    static uint32_t last_time;
-    static uint16_t last_cycle_count;
-
-    int valid;
-    int on_time;
-
-    uint16_t cur_cycle_count;
-    uint16_t delta_cycles;
-    uint32_t cur_time;
-    uint32_t delta_time;
-
-    if (PORT_MCLK == 0) {
-        return;
-    }
-
-    asm volatile(
-            "{gettime %0; getts %1, res[%2]}"
-            : "=r"(cur_time), "=r"(cur_cycle_count)
-            : "r"(PORT_MCLK)
-            : /* no clobbers */
-            );
-
-    delta_time = cur_time - last_time;
-    last_time = cur_time;
-    valid = delta_time >= SOF_DELTA_TIME_VALID_LOWER && delta_time <= SOF_DELTA_TIME_VALID_UPPER;
-    on_time = delta_time >= SOF_DELTA_TIME_ON_TIME_LOWER && delta_time <= SOF_DELTA_TIME_ON_TIME_UPPER;
-
-    delta_cycles = cur_cycle_count - last_cycle_count;
-    last_cycle_count = cur_cycle_count;
-
-    if (valid) {
-
-        int32_t error = DELTA_CYCLES_TARGET - delta_cycles;
-
-        /*
-         * Always integrate the error, even if this SOF is not on time.
-         * Late SOFs are always followed by early SOFs, so the integrated
-         * error will even out, even if the current error value is off.
-         */
-        integral += error;
-
-        /*
-         * If the current SOF came in either a little late or early (as
-         * measured by the reference clock) then the instantaneous error
-         * cannot be trusted, and no adjustment to the PLL frequency should
-         * be made.
-         */
-        if (on_time) {
-            const int32_t kp = Q(P)(0.1);
-            const int32_t ki = Q(P)(0.0001);
-            const int32_t kd = Q(P)(0);
-
-            int32_t output;
-            int32_t numerator_int;
-            const int32_t proportional = error;
-            const int32_t derivative = error - previous_error;
-            previous_error = error;
-
-            output = dsp_math_multiply(kp, proportional, 0) +
-                     dsp_math_multiply(ki, integral, 0) +
-                     dsp_math_multiply(kd, derivative, 0);
-
-            numerator += output;
-            if (numerator > Q(P)(255)) {
-                numerator = Q(P)(255);
-            } else if (numerator < 0) {
-                numerator = 0;
-            }
-
-            numerator_int = (numerator + Q(P)(0.5)) >> P;
-
-            output += Q(P)(0.5);
-            output >>= P;
-            rtos_printf("%u (%d, %d, %d) -> %d -> %d\n", delta_cycles,
-                        proportional, integral, derivative,
-                        output, numerator_int);
-
-            app_pll_set_numerator(numerator_int);
-            xscope_int(PLL_FREQ, numerator_int);
-        } else {
-            rtos_printf("no adjustment from PID\n");
-        }
-
-    } else {
-        /*
-         * The SOF arrived far too late or early. Reset the error state,
-         * but leave the current PLL frequency alone. This might be due
-         * to a USB reset for example.
-         */
-        previous_error = 0;
-        integral = 0;
-        rtos_printf("reset PID\n");
-    }
-}
-
 static chanend_t sof_t1_isr_c;
+
+bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size_t xfer_len)
+{
+    if (ep_num == USB_AUDIO_EP &&
+        ep_dir == USB_DIR_OUT)
+    {
+        uint32_t data_rate = determine_USB_audio_rate(cur_time, xfer_len, ep_dir, true);
+        uint64_t s = (uint64_t)data_rate; 
+        /* The below manipulations calculate the required f value to scale the nominal app PLL (24.576MHz) by the data rate.
+         * The relevant equations are from the XU316 datasheet, and are:
+         *
+         *                     F + 1 + (f+1 / p+1)      1          1
+         * Fpll2 = Fpll2_in *  ------------------- * ------- * --------
+         *                             2              R + 1     OD + 1
+         * 
+         * For given values:
+         *  Fpll2_in = 24 (MHz, from oscillator)
+         *  F = 408
+         *  R = 3
+         *  OD = 4
+         *  p = 249
+         * and expressing Fpll2 as X*s, where X is the nominal frequency and S is the scale applied, we can 
+         * rearrange and simplify to give: 
+         *
+         *      [ f + p + 2     ]           
+         *  6 * [ --------- + F ]
+         *      [   f + 1       ]   
+         *  ---------------------- 
+         *  5 * (D + 1) * (R + 1)    = X*s, substituting in values to give
+         * 
+         *
+         *      [ f + 251         ]           
+         *  6 * [ --------- + 408 ]
+         *      [   250           ]   
+         *  ---------------------- 
+         *              100         = 24.576 * s, solving for f and simplifying to give
+         * 
+         * 
+         * f = (102400 * s) - 102251, rounded and converted back to an integer from Q31.
+         */
+
+        s *= 102400;
+        s -= (102251 << 31);
+        s >>= 30;
+        s = (s % 2) ? (s >> 1) + 1 : s >> 1;
+
+        app_pll_set_numerator((int)s);
+    }
+    return true;
+}
 
 bool tud_xcore_sof_cb(uint8_t rhport)
 {
-#if !appconfEXTERNAL_MCLK
 #if XCOREAI_EXPLORER
-    sof_cb();
+    sof_toggle();
 #else
     chanend_out_end_token(sof_t1_isr_c);
 #endif
+
     /* False tells TinyUSB to not send the SOF event to the stack */
     return false;
-#else
-    return true;
-#endif
 }
 
 DEFINE_RTOS_INTERRUPT_CALLBACK(sof_t1_isr, arg)
@@ -224,7 +102,7 @@ DEFINE_RTOS_INTERRUPT_CALLBACK(sof_t1_isr, arg)
     (void) arg;
 
     chanend_check_end_token(sof_t1_isr_c);
-    sof_cb();
+    sof_toggle();
 }
 
 #if XK_VOICE_L71 || OSPREY_BOARD

--- a/applications/stlp/src/usb/adaptive_rate_adjust.c
+++ b/applications/stlp/src/usb/adaptive_rate_adjust.c
@@ -40,6 +40,7 @@ bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size
     if (ep_num == USB_AUDIO_EP &&
         ep_dir == USB_DIR_OUT)
     {
+        static uint64_t prev_s;
         uint32_t data_rate = determine_USB_audio_rate(cur_time, xfer_len, ep_dir, true);
         uint64_t s = (uint64_t)data_rate; 
         /* The below manipulations calculate the required f value to scale the nominal app PLL (24.576MHz) by the data rate.
@@ -80,7 +81,13 @@ bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size
         s >>= 30;
         s = (s % 2) ? (s >> 1) + 1 : s >> 1;
 
-        app_pll_set_numerator((int)s);
+        if (s != prev_s)
+        {
+            app_pll_set_numerator((int)s);
+            rtos_printf("New App PLL numerator: %d, data rate: %d\n", (int)s, data_rate);
+        }
+
+        prev_s = s;
     }
     return true;
 }

--- a/applications/stlp/src/usb/adaptive_rate_adjust.c
+++ b/applications/stlp/src/usb/adaptive_rate_adjust.c
@@ -76,7 +76,7 @@ bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size
          */
 
         s *= 102400;
-        s -= (102251 << 31);
+        s -= ((uint64_t)102251 << 31);
         s >>= 30;
         s = (s % 2) ? (s >> 1) + 1 : s >> 1;
 

--- a/applications/stlp/src/usb/adaptive_rate_adjust.c
+++ b/applications/stlp/src/usb/adaptive_rate_adjust.c
@@ -21,20 +21,6 @@
 
 #include "platform/app_pll_ctrl.h"
 
-#if XK_VOICE_L71
-#define PORT_MCLK       PORT_MCLK_IN_OUT
-#elif XCOREAI_EXPLORER
-#define PORT_MCLK       PORT_MCLK_IN
-#elif OSPREY_BOARD
-#define PORT_MCLK       PORT_MCLK_IN
-#else
-#ifndef PORT_MCLK
-#define PORT_MCLK       0
-#endif
-#endif
-
-static chanend_t sof_t1_isr_c;
-
 bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size_t xfer_len)
 {
     if (ep_num == USB_AUDIO_EP &&
@@ -84,7 +70,7 @@ bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size
         if (s != prev_s)
         {
             app_pll_set_numerator((int)s);
-            rtos_printf("New App PLL numerator: %d, data rate: %d\n", (int)s, data_rate);
+            //rtos_printf("New App PLL numerator: %d, data rate: %u\n", (int)s, data_rate);
         }
 
         prev_s = s;
@@ -94,91 +80,12 @@ bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size
 
 bool tud_xcore_sof_cb(uint8_t rhport)
 {
-#if !appconfEXTERNAL_MCLK
-#if XCOREAI_EXPLORER
     sof_toggle();
-#else
-    chanend_out_end_token(sof_t1_isr_c);
-#endif
 
     /* False tells TinyUSB to not send the SOF event to the stack */
     return false;
-#else
-    return true;
-#endif
 }
-
-DEFINE_RTOS_INTERRUPT_CALLBACK(sof_t1_isr, arg)
-{
-    (void) arg;
-
-    chanend_check_end_token(sof_t1_isr_c);
-    sof_toggle();
-}
-
-#if XK_VOICE_L71 || OSPREY_BOARD
-static void sof_intertile_init(chanend_t other_tile_c)
-{
-    sof_t1_isr_c = chanend_alloc();
-    xassert(sof_t1_isr_c != 0);
-
-#if ON_TILE(1)
-    chanend_out_word(other_tile_c, sof_t1_isr_c);
-    chanend_out_end_token(other_tile_c);
-#endif
-#if ON_TILE(0)
-    chanend_set_dest(sof_t1_isr_c, chanend_in_word(other_tile_c));
-    chanend_check_end_token(other_tile_c);
-#endif
-
-#if ON_TILE(1)
-    /*
-     * TODO: Move this to adaptive_rate_adjust_start() perhaps,
-     * and then call it from platform_start().
-     * It could then support enabling the ISR on a specified core.
-     * ATM, the ISR will run on whatever core is running prior to
-     * the RTOS starting, which isn't guaranteed to be anything,
-     * though seems to always be RTOS core 0. This is fine, but
-     * the tick interrupt can interfere, and if it does happen to
-     * end up on the mic or i2s cores, that might be bad.
-     */
-    triggerable_setup_interrupt_callback(sof_t1_isr_c,
-                                         NULL,
-                                         RTOS_INTERRUPT_CALLBACK(sof_t1_isr));
-    triggerable_enable_trigger(sof_t1_isr_c);
-#endif
-}
-#endif
 
 void adaptive_rate_adjust_init(chanend_t other_tile_c, xclock_t mclk_clkblk)
 {
-#if (XCOREAI_EXPLORER && ON_TILE(0)) || ((XK_VOICE_L71 || OSPREY_BOARD) && ON_TILE(1))
-    /*
-     * Configure the MCLK input port on the tile that
-     * will run sof_cb() and count its clock cycles.
-     *
-     * On the Explorer board the appPLL/MCLK output from
-     * tile 1 is wired over to tile 0. On the Osprey and
-     * 3610 boards it is not.
-     *
-     * It is set up to clock itself. This allows GETTS to
-     * be called on it to count its clock cycles. This
-     * count is used to adjust its frequency to match the
-     * USB host.
-     */
-    port_enable(PORT_MCLK);
-    clock_enable(mclk_clkblk);
-    clock_set_source_port(mclk_clkblk, PORT_MCLK);
-    port_set_clock(PORT_MCLK, mclk_clkblk);
-    clock_start(mclk_clkblk);
-#endif
-#if XK_VOICE_L71 || OSPREY_BOARD
-    /*
-     * On the Osprey and 3610 boards an additional intertile
-     * channel and ISR must be set up in order to run the
-     * SOF ISR on tile 1, since MCLK is not wired over to
-     * tile 0.
-     */
-    sof_intertile_init(other_tile_c);
-#endif
 }

--- a/applications/stlp/src/usb/adaptive_rate_adjust.c
+++ b/applications/stlp/src/usb/adaptive_rate_adjust.c
@@ -87,6 +87,7 @@ bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size
 
 bool tud_xcore_sof_cb(uint8_t rhport)
 {
+#if !appconfEXTERNAL_MCLK
 #if XCOREAI_EXPLORER
     sof_toggle();
 #else
@@ -95,6 +96,9 @@ bool tud_xcore_sof_cb(uint8_t rhport)
 
     /* False tells TinyUSB to not send the SOF event to the stack */
     return false;
+#else
+    return true;
+#endif
 }
 
 DEFINE_RTOS_INTERRUPT_CALLBACK(sof_t1_isr, arg)

--- a/applications/stlp/src/usb/adaptive_rate_adjust.h
+++ b/applications/stlp/src/usb/adaptive_rate_adjust.h
@@ -7,6 +7,9 @@
 #include <xcore/channel.h>
 #include <xcore/clock.h>
 
+#define USB_DIR_OUT 0
+#define USB_DIR_IN  1
+
 /* Add q formats as a hack to build */
 #define Q0(N) Q ## N
 #define Q(N) Q0(N)
@@ -39,5 +42,8 @@
 #define Q8(f)  (int)((signed long long)((f) * ((unsigned long long)1 << (8+20)) + (1<<19)) >> 20)
 
 void adaptive_rate_adjust_init(chanend_t other_tile_c, xclock_t mclk_clkblk);
+uint32_t determine_USB_audio_rate(uint32_t timestamp,
+                                        uint32_t data_length,
+                                        uint32_t direction);
 
 #endif /* ADAPTIVE_RATE_ADJUST_H_ */

--- a/applications/stlp/src/usb/adaptive_rate_adjust.h
+++ b/applications/stlp/src/usb/adaptive_rate_adjust.h
@@ -42,8 +42,5 @@
 #define Q8(f)  (int)((signed long long)((f) * ((unsigned long long)1 << (8+20)) + (1<<19)) >> 20)
 
 void adaptive_rate_adjust_init(chanend_t other_tile_c, xclock_t mclk_clkblk);
-uint32_t determine_USB_audio_rate(uint32_t timestamp,
-                                        uint32_t data_length,
-                                        uint32_t direction);
 
 #endif /* ADAPTIVE_RATE_ADJUST_H_ */

--- a/applications/stlp/src/usb/adaptive_rate_callback.c
+++ b/applications/stlp/src/usb/adaptive_rate_callback.c
@@ -111,7 +111,7 @@ uint32_t determine_USB_audio_rate(uint32_t timestamp,
     {
         hold_average = false;
         first_timestamp[direction] = timestamp;
-        return previous_result;
+        return previous_result[direction];
     }
 
     if (first_time[direction])

--- a/applications/stlp/src/usb/adaptive_rate_callback.c
+++ b/applications/stlp/src/usb/adaptive_rate_callback.c
@@ -1,0 +1,211 @@
+// Copyright 2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define TOTAL_TAIL_SECONDS 16
+#define STORED_PER_SECOND 4
+
+#if __xcore__
+#include "tusb_config.h"
+#include "app_conf.h"
+#define EXPECTED_OUT_BYTES_PER_SECOND (CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX * \
+                                       CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX * \
+                                       appconfAUDIO_PIPELINE_SAMPLE_RATE / 1000)
+#define EXPECTED_IN_BYTES_PER_SECOND  (CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX * \
+                                       CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX * \
+                                       appconfAUDIO_PIPELINE_SAMPLE_RATE / 1000)
+#else //__xcore__
+// If we're compiling this for x86 we're probably testing it - just assume some values
+#define EXPECTED_OUT_BYTES_PER_SECOND  128 //16kbps * 16-bit * 4ch
+#define EXPECTED_IN_BYTES_PER_SECOND   192 //16kbps * 16-bit * 6ch
+#endif //__xcore__
+
+#define TOTAL_STORED (TOTAL_TAIL_SECONDS * STORED_PER_SECOND)
+#define REF_CLOCK_TICKS_PER_STORED_AVG (REF_CLOCK_TICKS_PER_SECOND / STORED_PER_SECOND)
+#define REF_CLOCK_TICKS_PER_SECOND 100000000
+#define NOMINAL_RATE (1 << 31)
+
+bool first_time[2] = {true, true};
+bool data_seen = false;
+bool hold_average = false;
+uint32_t expected[2] = {EXPECTED_OUT_BYTES_PER_SECOND, EXPECTED_IN_BYTES_PER_SECOND};
+
+#if __xcore__
+uint32_t dsp_math_divide_unsigned(uint32_t dividend, uint32_t divisor, uint32_t q_format )
+{
+    //h and l hold a 64-bit value
+    uint32_t h; uint32_t l;
+    uint32_t quotient=0, remainder=0;
+
+    // Create long dividend by shift dividend up q_format positions
+    h = dividend >> (32-q_format);
+    l = dividend << (q_format);
+
+    // Unsigned Long division
+    asm("ldivu %0,%1,%2,%3,%4":"=r"(quotient):"r"(remainder),"r"(h),"r"(l),"r"(divisor));
+
+    return quotient;
+}
+#else //__xcore__
+// If we're compiling this for x86 we're probably testing it - let the compiler work out the ASM for this
+
+uint32_t dsp_math_divide_unsigned(uint32_t dividend, uint32_t divisor, uint32_t q_format )
+{
+    uint64_t h = (uint64_t)dividend << q_format;
+    uint64_t quotient = h / divisor;
+
+    return (uint32_t)quotient;
+}
+#endif //__xcore__
+
+
+uint32_t dsp_math_divide_unsigned_64(uint64_t dividend, uint32_t divisor, uint32_t q_format )
+{
+    uint64_t h = dividend << q_format;
+    uint64_t quotient = h / divisor;
+
+    return (uint32_t)quotient;
+}
+
+uint32_t sum_array(uint32_t * array_to_sum, uint32_t array_length)
+{
+    uint32_t acc = 0;
+    for (uint32_t i = 0; i < array_length; i++)
+    {
+        acc += array_to_sum[i];
+    }
+    return acc;
+}
+
+void reset_state()
+{
+    for (int direction = 0; direction < 2; direction++)
+    {
+        first_time[direction] = true;
+    }
+}
+
+uint32_t determine_USB_audio_rate(uint32_t timestamp,
+                                    uint32_t data_length,
+                                    uint32_t direction,
+                                    bool update
+#ifdef DEBUG_ADAPTIVE
+                                                ,
+                                    uint32_t * debug
+#endif                                              
+)
+{
+    static uint32_t data_lengths[2][TOTAL_STORED];
+    static uint32_t time_buckets[2][TOTAL_STORED];
+    static uint32_t current_data_bucket_size[2];
+    static uint32_t first_timestamp[2];
+    static bool buckets_full[2];
+    static uint32_t times_overflowed[2];
+    static uint32_t previous_result[2];
+
+    data_seen = true;
+
+    if (hold_average)
+    {
+        hold_average = false;
+        first_timestamp[direction] = timestamp;
+        return previous_result;
+    }
+
+    if (first_time[direction])
+    {
+        first_time[direction] = false;
+        first_timestamp[direction] = timestamp;
+
+        // Because we use "first_time" to also reset the rate determinator, 
+        // reset all the static variables to default.
+        current_data_bucket_size[direction] = 0;
+        times_overflowed[direction] = 0;
+        buckets_full[direction] = false;
+
+        for (int i = 0; i < TOTAL_STORED; i++)
+        {
+            data_lengths[direction][i] = 0;
+            time_buckets[direction][i] = 0;
+        }
+
+        return NOMINAL_RATE;
+    }
+
+    if (update)
+    {
+        current_data_bucket_size[direction] += data_length;
+    }
+    
+    // total_timespan is always correct regardless of whether the reference clock has overflowed.
+    // The point at which it becomes incorrect is the point at which it would overflow - the
+    // point at which timestamp == first_timestamp again. This will be at 42.95 seconds of operation.
+    // If current_data_bucket_size overflows we have bigger issues, so this case is not guarded.
+
+    uint32_t timespan = timestamp - first_timestamp[direction];
+    uint32_t total_data_intermed = current_data_bucket_size[direction] + sum_array(data_lengths[direction], TOTAL_STORED);
+    uint64_t total_data = (uint64_t)(total_data_intermed) * 12500;
+    uint32_t total_timespan = timespan + sum_array(time_buckets[direction], TOTAL_STORED);
+
+    uint32_t data_per_sample = dsp_math_divide_unsigned_64(total_data, (total_timespan / 8), 19);
+    uint32_t result = dsp_math_divide_unsigned(data_per_sample, expected[direction], 12);
+
+    if (update && (timespan >= REF_CLOCK_TICKS_PER_STORED_AVG))
+    {
+        if (buckets_full[direction])
+        {
+            // We've got enough data for a new bucket - replace the oldest bucket data with this new data
+            uint32_t oldest_bucket = times_overflowed[direction] % TOTAL_STORED;
+
+            time_buckets[direction][oldest_bucket] = timespan;
+            data_lengths[direction][oldest_bucket] = current_data_bucket_size[direction];
+
+            current_data_bucket_size[direction] = 0;
+            first_timestamp[direction] = timestamp;
+
+            times_overflowed[direction]++;
+        }
+        else
+        {
+            // We've got enough data for this bucket - save this one and start the next one
+            time_buckets[direction][times_overflowed[direction]] = timespan;
+            data_lengths[direction][times_overflowed[direction]] = current_data_bucket_size[direction];
+
+            current_data_bucket_size[direction] = 0;
+            first_timestamp[direction] = timestamp;
+
+            times_overflowed[direction]++;
+            if (times_overflowed[direction] == TOTAL_STORED)
+            {
+                buckets_full[direction] = true;
+            }
+        }
+    }
+
+#ifdef DEBUG_ADAPTIVE
+    #define DEBUG_QUANT 4
+
+    uint32_t debug_out[DEBUG_QUANT] = {result, data_per_sample, total_data_intermed, total_timespan};
+    for (int i = 0; i < DEBUG_QUANT; i++)
+    {
+        debug[i] = debug_out[i];
+    }
+#endif
+
+    previous_result[direction] = result;
+    return result;
+}
+
+void sof_toggle()
+{
+    if (data_seen)
+    {
+        data_seen = false;
+    }
+    else
+    {
+        hold_average = true;
+    }
+}

--- a/applications/stlp/src/usb/adaptive_rate_callback.h
+++ b/applications/stlp/src/usb/adaptive_rate_callback.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 
 
-float determine_USB_audio_rate(uint32_t timestamp,
+uint32_t determine_USB_audio_rate(uint32_t timestamp,
                                     uint32_t data_length,
                                     uint32_t direction,
                                     bool update);

--- a/applications/stlp/src/usb/adaptive_rate_callback.h
+++ b/applications/stlp/src/usb/adaptive_rate_callback.h
@@ -1,0 +1,15 @@
+// Copyright 2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+// This file intentionally only includes pure generic C constructs to allow compilation and testing by an x86 processor.
+
+#include <stdint.h>
+#include <stdbool.h>
+
+
+float determine_USB_audio_rate(uint32_t timestamp,
+                                    uint32_t data_length,
+                                    uint32_t direction,
+                                    bool update);
+void reset_state();
+void sof_toggle();

--- a/applications/stlp/src/usb/tusb_config.h
+++ b/applications/stlp/src/usb/tusb_config.h
@@ -99,7 +99,7 @@ extern const uint16_t tud_audio_desc_lengths[CFG_TUD_AUDIO];
 
 #define CFG_TUD_AUDIO_ENABLE_EP_OUT                 1
 #define CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ              (AUDIO_FRAMES_PER_USB_FRAME * CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX)
-#define CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ_MAX          (CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ + 2)   // Maximum EP IN size for all AS alternate settings used. Plus 2 for CRC
+#define CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ_MAX          (CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ + 2)   // Maximum EP OUT size for all AS alternate settings used. Plus 2 for CRC
 #define CFG_TUD_AUDIO_FUNC_1_EP_OUT_SW_BUF_SZ       CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ*3
 
 #endif /* _TUSB_CONFIG_H_ */

--- a/applications/stlp/src/usb/usb_audio.c
+++ b/applications/stlp/src/usb/usb_audio.c
@@ -58,8 +58,12 @@ audio_control_range_4_n_t(1) sampleFreqRng; 						// Sample frequency range stat
 static volatile bool mic_interface_open = false;
 static volatile bool spkr_interface_open = false;
 
+static uint32_t prev_n_bytes_received = 0;
+static bool host_streaming_out = false;
+
 static StreamBufferHandle_t samples_to_host_stream_buf;
 static StreamBufferHandle_t samples_from_host_stream_buf;
+static StreamBufferHandle_t rx_buffer;
 static TaskHandle_t usb_audio_out_task_handle;
 
 #define RATE_MULTIPLIER (appconfUSB_AUDIO_SAMPLE_RATE / appconfAUDIO_PIPELINE_SAMPLE_RATE)
@@ -176,6 +180,7 @@ void usb_audio_recv(rtos_intertile_t *intertile_ctx,
     }
 
     if (frame_buf_ptr != NULL) {
+        memset(frame_buf_ptr, 0, sizeof(int32_t) * appconfAUDIO_PIPELINE_FRAME_ADVANCE * num_chans);
         for(int ch=0; ch<CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX; ch++) {
             for (int i=0; i<appconfAUDIO_PIPELINE_FRAME_ADVANCE; i++) {
                 if (ch < num_chans) {
@@ -494,81 +499,102 @@ bool tud_audio_rx_done_post_read_cb(uint8_t rhport,
                                     uint8_t ep_out,
                                     uint8_t cur_alt_setting)
 {
-  (void)rhport;
+    (void)rhport;
+  
+    samp_t rx_data[CFG_TUD_AUDIO_FUNC_1_EP_OUT_SW_BUF_SZ];
+    samp_t usb_audio_frames[AUDIO_FRAMES_PER_USB_FRAME][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX];
+    const size_t stream_buffer_send_byte_count = sizeof(usb_audio_frames) / RATE_MULTIPLIER;
 
-  samp_t usb_audio_frames[AUDIO_FRAMES_PER_USB_FRAME][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX];
+    host_streaming_out = true;
+    prev_n_bytes_received = n_bytes_received;
+  
+    if (!spkr_interface_open) {
+        spkr_interface_open = true;
+    }
 
-  const size_t stream_buffer_send_byte_count = sizeof(usb_audio_frames) / RATE_MULTIPLIER;
+    /* 
+     * rx_data is a holding space to recieve the latest USB transaction.
+     * If it fits, we then push into rx_buffer. This could be a nominal-size transaction, or it could not be.
+     * We then only push nominal size transactions into the stream buffer.
+     * Hopefully this doesn't cause timing issues in the pipeline.
+     */
 
-  /*
-   * TODO: For adaptive mode (vs synchronous) then we need to
-   * add support for frames that do not have the
-   * nominal number of audio frames (16 or 48).
-   * - What should the limit be? 2x maybe?
-   * - Would we still require a whole number of audio frames?
-   */
-  if (n_bytes_received != sizeof(usb_audio_frames)) {
-      return false;
-  }
+    if (sizeof(rx_data) >= n_bytes_received)
+    {
+        tud_audio_read(rx_data, n_bytes_received);
+    }
+    else
+    {
+        /* 
+         * I don't believe we ever get here because I think the EP FIFO will complain before this, 
+         * but better safe than sorry
+         */
+        rtos_printf("Rx'd too much USB data in one transaction, cannot read\n");
+        return false;
+    }
 
-  if (!spkr_interface_open) {
-      spkr_interface_open = true;
-  }
+    if (xStreamBufferSpacesAvailable(rx_buffer) >= n_bytes_received)
+    {
+        xStreamBufferSend(rx_buffer, rx_data, n_bytes_received);
+    }
+    else
+    {
+        rtos_printf("Rx'd too much total USB data, cannot buffer\n");
+        return false;
+    }
+    
+    if (xStreamBufferBytesAvailable(rx_data) >= sizeof(usb_audio_frames))
+    {
+        xStreamBufferReceive(rx_data, usb_audio_frames, sizeof(usb_audio_frames), 0);
+    }
+    else
+    {
+        rtos_printf("Not enough data to send to stream buffer, cycling again");
+        return true;
+    }
 
-  tud_audio_read(usb_audio_frames, n_bytes_received);
-
-  if (xStreamBufferSpacesAvailable(samples_from_host_stream_buf) >= stream_buffer_send_byte_count) {
-
-      if (RATE_MULTIPLIER == 3) {
-          static int32_t src_data[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX][SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_PHASE] __attribute__((aligned (8)));
-          samp_t stream_buffer_audio_frames[AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX];
-
-          /*
-           * TODO: For adaptive mode, use the actual number of audio frames
-           * received, not AUDIO_FRAMES_PER_USB_FRAME. This would require
-           * that a whole number of audio frames were contained within the
-           * USB packet. It would also require the number of frames to be a multiple
-           * of RATE_MULTIPLIER. Maybe we need to keep a static buffer around, and then
-           * run this bit as is, still sending only AUDIO_FRAMES_PER_USB_FRAME at a time
-           * to the stream buffer.
-           */
-          for (int i = 0; i < AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER; i++) {
-              for (int j = 0; j < CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX; j++) {
-                  int64_t sum = 0;
-                  sum = src_ds3_voice_add_sample(sum, src_data[j][0], src_ff3v_fir_coefs[0], usb_audio_frames[3*i + 0][j]);
-                  sum = src_ds3_voice_add_sample(sum, src_data[j][1], src_ff3v_fir_coefs[1], usb_audio_frames[3*i + 1][j]);
-                  stream_buffer_audio_frames[i][j] = src_ds3_voice_add_final_sample(sum, src_data[j][2], src_ff3v_fir_coefs[2], usb_audio_frames[3*i + 2][j]);
-              }
-          }
-          xStreamBufferSend(samples_from_host_stream_buf, stream_buffer_audio_frames, stream_buffer_send_byte_count, 0);
-      } else {
-          xStreamBufferSend(samples_from_host_stream_buf, usb_audio_frames, stream_buffer_send_byte_count, 0);
-      }
-
-      /*
-       * Wake up the task waiting on this buffer whenever there is one more
-       * USB frame worth of audio data than the amount of data required to
-       * be input into the pipeline.
-       *
-       * This way the task will not wake up each time this task puts another
-       * milliseconds of audio into the stream buffer, but rather once every
-       * pipeline frame time.
-       */
-      const size_t buffer_notify_level = stream_buffer_send_byte_count * (1 + USB_FRAMES_PER_VFE_FRAME);
-
-      /*
-       * TODO: If the above is modified such that not exactly AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER
-       * frames are written to the stream buffer at a time, then this will need to change to >=.
-       */
-      if (xStreamBufferBytesAvailable(samples_from_host_stream_buf) == buffer_notify_level) {
-          xTaskNotifyGive(usb_audio_out_task_handle);
-      }
-
-  } else {
-      rtos_printf("lost USB output samples\n");
-  }
-
-  return true;
+    if (xStreamBufferSpacesAvailable(samples_from_host_stream_buf) >= stream_buffer_send_byte_count)
+    {
+        if (RATE_MULTIPLIER == 3) {
+            static int32_t src_data[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX][SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_PHASE] __attribute__((aligned (8)));
+            samp_t stream_buffer_audio_frames[AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX];
+  
+            for (int i = 0; i < AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER; i++) {
+                for (int j = 0; j < CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX; j++) {
+                    int64_t sum = 0;
+                    sum = src_ds3_voice_add_sample(sum, src_data[j][0], src_ff3v_fir_coefs[0], usb_audio_frames[3*i + 0][j]);
+                    sum = src_ds3_voice_add_sample(sum, src_data[j][1], src_ff3v_fir_coefs[1], usb_audio_frames[3*i + 1][j]);
+                    stream_buffer_audio_frames[i][j] = src_ds3_voice_add_final_sample(sum, src_data[j][2], src_ff3v_fir_coefs[2], usb_audio_frames[3*i + 2][j]);
+                }
+            }
+            xStreamBufferSend(samples_from_host_stream_buf, stream_buffer_audio_frames, stream_buffer_send_byte_count, 0);
+        } else {
+            xStreamBufferSend(samples_from_host_stream_buf, usb_audio_frames, stream_buffer_send_byte_count, 0);
+        }
+  
+        /*
+         * Wake up the task waiting on this buffer whenever there is one more
+         * USB frame worth of audio data than the amount of data required to
+         * be input into the pipeline.
+         *
+         * This way the task will not wake up each time this task puts another
+         * milliseconds of audio into the stream buffer, but rather once every
+         * pipeline frame time.
+         */
+        const size_t buffer_notify_level = stream_buffer_send_byte_count * (1 + USB_FRAMES_PER_VFE_FRAME);
+  
+        /*
+         * TODO: If the above is modified such that not exactly AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER
+         * frames are written to the stream buffer at a time, then this will need to change to >=.
+         */
+        if (xStreamBufferBytesAvailable(samples_from_host_stream_buf) == buffer_notify_level) {
+            xTaskNotifyGive(usb_audio_out_task_handle);
+        }
+    } else {
+        rtos_printf("lost USB output samples\n");
+    }
+  
+    return true;
 }
 
 bool tud_audio_tx_done_pre_load_cb(uint8_t rhport,
@@ -577,8 +603,33 @@ bool tud_audio_tx_done_pre_load_cb(uint8_t rhport,
                                    uint8_t cur_alt_setting)
 {
     static int ready;
-    samp_t stream_buffer_audio_frames[AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX];
     size_t bytes_available;
+    size_t tx_size_bytes;
+    size_t tx_size_frames;
+    /*
+     * This buffer needs to be large enough to hold any size of transaction,
+     * but if it's any bigger than twice nominal then we have bigger issues
+     */
+    samp_t stream_buffer_audio_frames[2 * AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX];
+
+    /*
+     * Copying XUA_lite logic basically verbatim - if the host is streaming out, 
+     * then we send back the number of samples per channel that we last received.
+     * If it's not, then we send the nominal number of samples per channel.
+     * This assumes (as with XUA_lite) that the host sends the same number of samples for each channel.
+     * This also assumes that TX and RX rates are the same, which is an assumption made elsewhere.
+     * This finally assumes that at nominal rate, 
+     *     AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER == prev_n_bytes_received / CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX
+     */
+    if (host_streaming_out && 0 != prev_n_bytes_received)
+    {
+        tx_size_bytes = prev_n_bytes_received * (CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX / CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX);
+    }
+    else
+    {
+        tx_size_bytes = (AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER) * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX;
+    }
+    tx_size_frames = tx_size_bytes / CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX;
 
     (void) rhport;
     (void) itf;
@@ -615,23 +666,24 @@ bool tud_audio_tx_done_pre_load_cb(uint8_t rhport,
         return true;
     }
 
-    if (bytes_available >= sizeof(stream_buffer_audio_frames)) {
-        xStreamBufferReceive(samples_to_host_stream_buf, stream_buffer_audio_frames, sizeof(stream_buffer_audio_frames), 0);
+    if (bytes_available >= tx_size_bytes) {
+        xStreamBufferReceive(samples_to_host_stream_buf, stream_buffer_audio_frames, tx_size_bytes, 0);
 
         if (RATE_MULTIPLIER == 3) {
             static int32_t src_data[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX][SRC_FF3V_FIR_TAPS_PER_PHASE] __attribute__((aligned (8)));
-            samp_t usb_audio_frames[AUDIO_FRAMES_PER_USB_FRAME][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX];
+            /* Again, this buffer has to be large enough to contain any size transaction */
+            samp_t usb_audio_frames[2*AUDIO_FRAMES_PER_USB_FRAME][CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX];
 
-            for (int i = 0; i < AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER; i++) {
+            for (int i = 0; i < tx_size_frames; i++) {
                 for (int j = 0; j < CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX; j++) {
                     usb_audio_frames[3*i + 0][j] = src_us3_voice_input_sample(src_data[j], src_ff3v_fir_coefs[2], stream_buffer_audio_frames[i][j]);
                     usb_audio_frames[3*i + 1][j] = src_us3_voice_get_next_sample(src_data[j], src_ff3v_fir_coefs[1]);
                     usb_audio_frames[3*i + 2][j] = src_us3_voice_get_next_sample(src_data[j], src_ff3v_fir_coefs[0]);
                 }
             }
-            tud_audio_write(usb_audio_frames, sizeof(usb_audio_frames));
+            tud_audio_write(usb_audio_frames, tx_size_frames);
         } else {
-            tud_audio_write(stream_buffer_audio_frames, sizeof(stream_buffer_audio_frames));
+            tud_audio_write(stream_buffer_audio_frames, tx_size_bytes);
         }
     } else {
         rtos_printf("Oops buffer is empty!\n");
@@ -668,6 +720,7 @@ bool tud_audio_set_itf_cb(uint8_t rhport,
          * closing it first */
         spkr_interface_open = false;
         xStreamBufferReset(samples_from_host_stream_buf);
+        xStreamBufferReset(rx_buffer);
     }
 #endif
 #if AUDIO_INPUT_ENABLED
@@ -718,6 +771,8 @@ void usb_audio_init(rtos_intertile_t *intertile_ctx,
     sampleFreqRng.subrange[0].bMin = appconfUSB_AUDIO_SAMPLE_RATE;
     sampleFreqRng.subrange[0].bMax = appconfUSB_AUDIO_SAMPLE_RATE;
     sampleFreqRng.subrange[0].bRes = 0;
+
+    rx_buffer = xStreamBufferCreate(CFG_TUD_AUDIO_FUNC_1_EP_OUT_SW_BUF_SZ, 0);
 
     /*
      * Note: Given the way that the USB callback notifies usb_audio_out_task,

--- a/applications/stlp/src/usb/usb_audio.c
+++ b/applications/stlp/src/usb/usb_audio.c
@@ -535,7 +535,7 @@ bool tud_audio_rx_done_post_read_cb(uint8_t rhport,
 
     if (xStreamBufferSpacesAvailable(rx_buffer) >= n_bytes_received)
     {
-        xStreamBufferSend(rx_buffer, rx_data, n_bytes_received);
+        xStreamBufferSend(rx_buffer, rx_data, n_bytes_received, 0);
     }
     else
     {
@@ -543,9 +543,9 @@ bool tud_audio_rx_done_post_read_cb(uint8_t rhport,
         return false;
     }
     
-    if (xStreamBufferBytesAvailable(rx_data) >= sizeof(usb_audio_frames))
+    if (xStreamBufferBytesAvailable(rx_buffer) >= sizeof(usb_audio_frames))
     {
-        xStreamBufferReceive(rx_data, usb_audio_frames, sizeof(usb_audio_frames), 0);
+        xStreamBufferReceive(rx_buffer, usb_audio_frames, sizeof(usb_audio_frames), 0);
     }
     else
     {

--- a/applications/stlp/src/usb/usb_audio.c
+++ b/applications/stlp/src/usb/usb_audio.c
@@ -622,13 +622,13 @@ bool tud_audio_tx_done_pre_load_cb(uint8_t rhport,
      */
     if (host_streaming_out && 0 != prev_n_bytes_received)
     {
-        tx_size_bytes = prev_n_bytes_received * (CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX / CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX);
+        tx_size_bytes = prev_n_bytes_received * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX / CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX;
     }
     else
     {
-        tx_size_bytes = (AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER) * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX;
+        tx_size_bytes = sizeof(samp_t) * (AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER) * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX;
     }
-    tx_size_frames = tx_size_bytes / CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX;
+    tx_size_frames = tx_size_bytes / (sizeof(samp_t) * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX);
 
     (void) rhport;
     (void) itf;

--- a/applications/stlp/src/usb/usb_audio.c
+++ b/applications/stlp/src/usb/usb_audio.c
@@ -180,7 +180,6 @@ void usb_audio_recv(rtos_intertile_t *intertile_ctx,
     }
 
     if (frame_buf_ptr != NULL) {
-        memset(frame_buf_ptr, 0, sizeof(int32_t) * appconfAUDIO_PIPELINE_FRAME_ADVANCE * num_chans);
         for(int ch=0; ch<CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX; ch++) {
             for (int i=0; i<appconfAUDIO_PIPELINE_FRAME_ADVANCE; i++) {
                 if (ch < num_chans) {

--- a/applications/stlp/src/usb/usb_descriptors.c
+++ b/applications/stlp/src/usb/usb_descriptors.c
@@ -175,7 +175,7 @@ uint8_t const desc_configuration[] = {
     /* Type I Format Type Descriptor(2.3.1.6 - Audio Formats) */
     TUD_AUDIO_DESC_TYPE_I_FORMAT(CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX, CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX*8),
     /* Standard AS Isochronous Audio Data Endpoint Descriptor(4.10.1.1) */
-    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_ADAPTIVE | TUSB_ISO_EP_ATT_IMPLICIT_FB | TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
+    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_ADAPTIVE | TUSB_ISO_EP_ATT_IMPLICIT_FB /*| TUSB_ISO_EP_ATT_DATA*/), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
     /* Class-Specific AS Isochronous Audio Data Endpoint Descriptor(4.10.1.2) */
     TUD_AUDIO_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO_CTRL_NONE, /*_lockdelayunit*/ AUDIO_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_MILLISEC, /*_lockdelay*/ 0x0003),
 #endif
@@ -192,7 +192,7 @@ uint8_t const desc_configuration[] = {
     /* Type I Format Type Descriptor(2.3.1.6 - Audio Formats) */
     TUD_AUDIO_DESC_TYPE_I_FORMAT(CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX, CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX*8),
     /* Standard AS Isochronous Audio Data Endpoint Descriptor(4.10.1.1) */
-    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ 0x80 | EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_ADAPTIVE | TUSB_ISO_EP_ATT_IMPLICIT_FB | TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_IN_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
+    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ 0x80 | EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_ADAPTIVE /*| TUSB_ISO_EP_ATT_IMPLICIT_FB */ | TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_IN_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
     /* Class-Specific AS Isochronous Audio Data Endpoint Descriptor(4.10.1.2) */
     TUD_AUDIO_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO_CTRL_NONE, /*_lockdelayunit*/ AUDIO_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_MILLISEC, /*_lockdelay*/ 0x0003),
 #endif

--- a/applications/stlp/src/usb/usb_descriptors.c
+++ b/applications/stlp/src/usb/usb_descriptors.c
@@ -175,7 +175,7 @@ uint8_t const desc_configuration[] = {
     /* Type I Format Type Descriptor(2.3.1.6 - Audio Formats) */
     TUD_AUDIO_DESC_TYPE_I_FORMAT(CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX, CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX*8),
     /* Standard AS Isochronous Audio Data Endpoint Descriptor(4.10.1.1) */
-    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_SYNCHRONOUS | /*TUSB_ISO_EP_ATT_IMPLICIT_FB |*/ TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
+    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_ADAPTIVE | TUSB_ISO_EP_ATT_IMPLICIT_FB | TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
     /* Class-Specific AS Isochronous Audio Data Endpoint Descriptor(4.10.1.2) */
     TUD_AUDIO_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO_CTRL_NONE, /*_lockdelayunit*/ AUDIO_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_MILLISEC, /*_lockdelay*/ 0x0003),
 #endif
@@ -192,7 +192,7 @@ uint8_t const desc_configuration[] = {
     /* Type I Format Type Descriptor(2.3.1.6 - Audio Formats) */
     TUD_AUDIO_DESC_TYPE_I_FORMAT(CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX, CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX*8),
     /* Standard AS Isochronous Audio Data Endpoint Descriptor(4.10.1.1) */
-    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ 0x80 | EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_SYNCHRONOUS | /*TUSB_ISO_EP_ATT_IMPLICIT_FB |*/ TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_IN_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
+    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ 0x80 | EPNUM_AUDIO, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_ADAPTIVE | TUSB_ISO_EP_ATT_IMPLICIT_FB | TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ CFG_TUD_AUDIO_FUNC_1_EP_IN_SZ, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),
     /* Class-Specific AS Isochronous Audio Data Endpoint Descriptor(4.10.1.2) */
     TUD_AUDIO_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO_CTRL_NONE, /*_lockdelayunit*/ AUDIO_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_MILLISEC, /*_lockdelay*/ 0x0003),
 #endif

--- a/applications/stlp/src/ww_model_runner/model_runner.c
+++ b/applications/stlp/src/ww_model_runner/model_runner.c
@@ -38,6 +38,6 @@ void model_runner_manager(void *args)
         } while(buf_len > 0);
 
         /* Perform inference here */
-        rtos_printf("inference\n");
+        // rtos_printf("inference\n");
     }
 }

--- a/test/applications/stlp/build_adaptive_rate_adjust.py
+++ b/test/applications/stlp/build_adaptive_rate_adjust.py
@@ -1,0 +1,56 @@
+# Copyright 2022 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+from cffi import FFI
+from shutil import rmtree
+
+def build_ffi():
+    # One more ../ than necessary - builds in the 'build' subdirectory in this folder
+    APPLICATION_ROOT = "../../../../applications/stlp"
+
+    FLAGS = [
+        '-std=c99',
+        '-fPIC'
+        ]
+
+    # Source file
+    SRCS = [f"{APPLICATION_ROOT}/src/usb/adaptive_rate_callback.c"]
+    INCLUDES = [f"{APPLICATION_ROOT}/src/usb/",
+                f"{APPLICATION_ROOT}/src/"]
+
+    # Units under test
+    ffibuilder = FFI()
+    ffibuilder.cdef(
+        """
+        uint32_t determine_USB_audio_rate(uint32_t timestamp,
+                                    uint32_t data_length,
+                                    uint32_t direction,
+                                    bool update,
+                                    uint32_t * debug);
+        void reset_state();
+        """
+    )
+
+    ffibuilder.set_source("adaptive_rate_adjust_api", 
+    """
+        #include <stdbool.h>
+        uint32_t determine_USB_audio_rate(uint32_t timestamp,
+                                    uint32_t data_length,
+                                    uint32_t direction,
+                                    bool update,
+                                    uint32_t * debug); 
+        void reset_state();
+    """,
+        sources=SRCS,
+        include_dirs=INCLUDES,
+        libraries=['m'],
+        extra_compile_args=FLAGS)
+
+    ffibuilder.compile(tmpdir="build", target="adaptive_rate_adjust_api.*", verbose=True)
+
+def clean_ffi():
+    rmtree("./build")
+
+
+if __name__ == "__main__":
+    build_ffi()

--- a/test/applications/stlp/test_adaptive_rate_adjust.py
+++ b/test/applications/stlp/test_adaptive_rate_adjust.py
@@ -1,0 +1,258 @@
+import random
+import pytest
+from fxpmath import Fxp
+
+from build_adaptive_rate_adjust import build_ffi, clean_ffi
+
+TICKS_PER_SECOND = 100000000
+TICKS_PER_MILLISECOND = 100000
+EXPECTED_OUT_BYTES_PER_SAMPLE = 128
+EXPECTED_IN_BYTES_PER_SAMPLE = 192
+EXPECTED_OUT_BYTES_PER_SECOND = EXPECTED_OUT_BYTES_PER_SAMPLE * 1000
+EXPECTED_IN_BYTES_PER_SECOND = EXPECTED_IN_BYTES_PER_SAMPLE * 1000
+INTMAX_32 = 4294967295
+DIR_OUT = 0
+DIR_IN = 1
+
+fxp_frac_gen = lambda val, frac : Fxp(val, signed=False, n_word=32, n_frac = frac)
+fxp_gen = lambda val : fxp_frac_gen(val, 31)
+parts_per_million = lambda val, ppm : (ppm/1000000) * val
+
+NOMINAL_RATE_NUMBER = 1
+NOMINAL_RATE = fxp_gen(NOMINAL_RATE_NUMBER)
+
+def convert_uut(timestamp, data_length, direction, update):
+    debug = ffi.new("uint32_t[4]")
+    result = determine_USB_audio_rate(timestamp, data_length, direction, update, debug)
+
+    dbg_res = fxp_gen(f"0b{debug[0]:032b}")
+    dbg_dps = fxp_frac_gen(f"0b{debug[1]:032b}", 19)
+    dbg_tdi = debug[2]
+    dbg_tt  = debug[3]
+
+    varstring = f"0b{result:032b}"
+    fxp = fxp_gen(varstring)
+    return fxp
+
+
+@pytest.fixture(scope="module")
+def build_uut():
+    # These are declared global so they may be used in the subsequent tests - bit of a hack
+    global adaptive_rate_adjust_api
+    global adaptive_rate_adjust_lib
+    global determine_USB_audio_rate
+    global ffi
+    global uut
+    global reset
+
+    build_ffi()
+
+    # Import the things we just built
+    from build import adaptive_rate_adjust_api
+    from adaptive_rate_adjust_api import ffi
+    import adaptive_rate_adjust_api.lib as adaptive_rate_adjust_lib
+    determine_USB_audio_rate = adaptive_rate_adjust_lib.determine_USB_audio_rate
+    reset = adaptive_rate_adjust_lib.reset_state
+
+    # The UUT returns values in UQ31 format. Cast this automagically
+    uut = convert_uut
+
+    yield
+
+    clean_ffi()
+
+# Test first call on OUT endpoint returns nominal rate no matter the actual input
+# and that reset actually resets the state
+def test_first_call(build_uut):
+    retval = uut(1, 10, DIR_OUT, True)
+    reset()
+    assert retval == NOMINAL_RATE
+
+    retval = uut(1, 10, DIR_OUT, True)
+    reset()
+    assert retval == NOMINAL_RATE
+
+# Test call on OUT endpoint does not impact IN endpoint and vice-versa
+def test_crosstalk(build_uut):
+    retval_out = uut(1, EXPECTED_OUT_BYTES_PER_SECOND, DIR_OUT, True)
+    retval_in = uut(1, EXPECTED_IN_BYTES_PER_SECOND, DIR_IN, True)
+    reset()
+
+    assert retval_in  == NOMINAL_RATE
+    assert retval_out == NOMINAL_RATE
+
+# Test two OUT data transactions at 1s and 2s return the nominal rate
+def test_two_call(build_uut):
+
+    _ = uut(TICKS_PER_SECOND, EXPECTED_OUT_BYTES_PER_SECOND, DIR_OUT, True)
+    retval = uut(2*TICKS_PER_SECOND, EXPECTED_OUT_BYTES_PER_SECOND, DIR_OUT, True)
+    reset()
+
+    assert retval == NOMINAL_RATE
+
+# Test three OUT data transactions at 1s, 2s, and 3s return the nominal rate
+def test_three_call(build_uut):
+    lobound = NOMINAL_RATE - parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+
+    _ = uut(TICKS_PER_SECOND, EXPECTED_OUT_BYTES_PER_SECOND, DIR_OUT, True)
+    _ = uut(2*TICKS_PER_SECOND, EXPECTED_OUT_BYTES_PER_SECOND, DIR_OUT, True)
+    retval = uut(3*TICKS_PER_SECOND, EXPECTED_OUT_BYTES_PER_SECOND, DIR_OUT, True)
+
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test 1 second of normal operation (1 transaction per millisecond) returns nominal rate
+def test_one_second(build_uut):
+    lobound = NOMINAL_RATE - parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+
+    for millis in range(1, 1001):
+        retval = uut(millis*TICKS_PER_MILLISECOND, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test that time can loop without jump in data
+def test_one_second_with_loop(build_uut):
+    lobound = NOMINAL_RATE - parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+    
+    offset = INTMAX_32 - (500 * TICKS_PER_MILLISECOND) # Should overflow halfway thru
+    for millis in range(1, 1001):
+        t = (offset + (millis*TICKS_PER_MILLISECOND)) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+    
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test that there can be >42.95 seconds of operation - causing the internal timer to overflow
+def test_forty_three_seconds(build_uut):
+    lobound = NOMINAL_RATE - parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+
+    for millis in range(1, 43001):
+        t = (millis*TICKS_PER_MILLISECOND) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test that there can be 240 seconds of operation - causing the internal timer to overflow multiple times
+def test_two_hundred_forty_seconds(build_uut):
+    lobound = NOMINAL_RATE - parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+
+    for millis in range(1, 240001):
+        t = (millis*TICKS_PER_MILLISECOND) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test what happens when the internal timer overflows while the average is changing
+def test_unstable_average_overflow(build_uut):
+    lobound = NOMINAL_RATE - parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+
+    for millis in range(1, 41001):
+        t = (millis*TICKS_PER_MILLISECOND) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+        assert lobound <= retval
+        assert retval <= hibound
+
+    for millis in range(41001, 50001):
+        t = (millis*TICKS_PER_MILLISECOND) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE+1, DIR_OUT, True)
+        assert lobound <= retval
+        # For 7s of nominal and 9s of +1 per sample, should expect
+        assert retval <= fxp_gen(1.00439453125)
+
+    reset()
+
+# Test what a minute of an extra byte per second looks like
+def test_slightly_fast(build_uut):
+    lobound = fxp_gen(1.0000078125) - parts_per_million(fxp_gen(1.0000078125), 1)
+    hibound = fxp_gen(1.0000078125) + parts_per_million(fxp_gen(1.0000078125), 1)
+
+    for seconds in range(1, 60):
+        # This is 1 second
+        for millis in range(1, 1000):
+            t = ((millis*TICKS_PER_MILLISECOND) + (seconds*TICKS_PER_SECOND)) % INTMAX_32
+            retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+            
+        millis += 1
+        t = ((millis*TICKS_PER_MILLISECOND) + (seconds*TICKS_PER_SECOND)) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE+1, DIR_OUT, True)
+
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test the same as previous, but with realistic jitter
+def test_slightly_fast_jitter(build_uut):
+    lobound = fxp_gen(1.0000078125) - parts_per_million(fxp_gen(1.0000078125), 1)
+    hibound = fxp_gen(1.0000078125) + parts_per_million(fxp_gen(1.0000078125), 1)
+    jitter = 100
+
+    for seconds in range(1, 60):
+        # This is 1 second
+        for millis in range(1, 1000):
+            t = (random.randint(-jitter, jitter) + (millis*TICKS_PER_MILLISECOND) + (seconds*TICKS_PER_SECOND)) % INTMAX_32
+            retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+            
+        millis += 1
+        t = (random.randint(-jitter, jitter) + (millis*TICKS_PER_MILLISECOND) + (seconds*TICKS_PER_SECOND)) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE+1, DIR_OUT, True)
+
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test that there can be 300 seconds of operation with realistic jitter
+def test_three_hundred_seconds_jitter(build_uut):
+    lobound = NOMINAL_RATE - parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+    jitter = 100
+
+    for millis in range(1, 300001):
+        t = (random.randint(-jitter, jitter) + (millis*TICKS_PER_MILLISECOND)) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+
+    reset()
+
+    assert lobound <= retval
+    assert retval <= hibound
+
+# Test 1ppm detection with jitter - simulates 128 seconds
+def test_one_part_per_million_jitter(build_uut):
+    lobound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 1)
+    hibound = NOMINAL_RATE + parts_per_million(NOMINAL_RATE, 2)
+    jitter = 100
+
+    for seconds in range(0, 8):
+        # This is 16 seconds
+        for millis in range(1, 16000):
+            t = (random.randint(-jitter, jitter) + (millis*TICKS_PER_MILLISECOND) + (16*seconds*TICKS_PER_SECOND)) % INTMAX_32
+            retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE, DIR_OUT, True)
+            
+        millis += 1
+        t = (random.randint(-jitter, jitter) + (millis*TICKS_PER_MILLISECOND) + (16*seconds*TICKS_PER_SECOND)) % INTMAX_32
+        retval = uut(t, EXPECTED_OUT_BYTES_PER_SAMPLE+2, DIR_OUT, True)
+
+    assert retval > lobound
+    assert retval < hibound
+
+    reset()

--- a/test/applications/test_applications.cmake
+++ b/test/applications/test_applications.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/stlp/test_stlp.cmake)

--- a/test/tests.cmake
+++ b/test/tests.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/applications/test_applications.cmake)


### PR DESCRIPTION
This PR replaces previous USB synchronous behaviour with USB adaptive behaviour in STLP.

Key understandings:

  - The contract we sign when we declare ourselves a USB adaptive device means that we _must_ send to the host at the same rate we receive from the host. In practice, we can simply mirror samples; the number we send the host should be equal to the number they sent us last.
  - In order for this to be buffered correctly, we must slow down or speed up our rate of data production in order to continue to feed the host data at the correct rate. 
  - In order to do this, we must speed up or slow down the app PLL to control how often we clock the mic array
  - To determine how the app PLL should be modified, the average data rate from the host must be estimated.

Caveats (thus far):
  - This has only been bench tested on 1 laptop using a voice reference design board and the UA_ADEC build. Testing on more systems may reveal as-yet-undetected pitfalls. 