### PR TITLE
Wanson recognition called in 30ms cycle

### DIFF
--- a/applications/ffd/inference/wanson/wanson_inf_eng.c
+++ b/applications/ffd/inference/wanson/wanson_inf_eng.c
@@ -40,7 +40,7 @@ void vDisplayClearCallback(TimerHandle_t pxTimer)
     inference_state = STATE_EXPECTING_WAKEWORD;
 }
 
-#pragma stackfunction 1200
+#pragma stackfunction 1500
 void wanson_engine_task(void *args)
 {
     inference_state = STATE_EXPECTING_WAKEWORD;
@@ -104,9 +104,8 @@ void wanson_engine_task(void *args)
             buf_ptr += bytes_rxed;
         } while(buf_len > 0);
 
-        /* Set second half of frame, as first contains last sample, also downshift for model format */
         for (int i=0; i<appconfINFERENCE_FRAMES_PER_INFERENCE; i++) {
-            buf_short[i + appconfINFERENCE_FRAMES_PER_INFERENCE] = buf[i] >> 16;
+            buf_short[i] = buf[i] >> 16;
         }
 
         /* Perform inference here */
@@ -140,9 +139,5 @@ void wanson_engine_task(void *args)
 #endif
         }
 
-        /* Push back history */
-        for (int i=0; i<appconfINFERENCE_FRAMES_PER_INFERENCE; i++) {
-            buf_short[i] = buf_short[i + appconfINFERENCE_FRAMES_PER_INFERENCE];
-        }
     }
 }

--- a/applications/ffd/src/app_conf.h
+++ b/applications/ffd/src/app_conf.h
@@ -29,7 +29,7 @@
 
 /* Intent Engine Configuration */
 #define appconfINFERENCE_FRAME_BUFFER_MULT      8       /* total buffer size is this value * MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME */
-#define appconfINFERENCE_FRAMES_PER_INFERENCE   240
+#define appconfINFERENCE_FRAMES_PER_INFERENCE   480
 
 /* Enable inference engine */
 #ifndef appconfINFERENCE_ENABLED


### PR DESCRIPTION
The API Wanson_ASR_Recog was designed to be called once in every 30ms. I am not sure if it would bring any improvement but it makes more sense to me to have the flow follows the library design.