### PR TITLE
Footprint estimates

### DIFF
--- a/applications/ffd/inference/wanson/wanson_inf_eng_support.c
+++ b/applications/ffd/inference/wanson/wanson_inf_eng_support.c
@@ -78,8 +78,8 @@ void wanson_engine_samples_send_local(
 void wanson_engine_task_create(unsigned priority)
 {
     samples_to_engine_stream_buf = xStreamBufferCreate(
-                                           2 * appconfAUDIO_PIPELINE_FRAME_ADVANCE,
-                                           appconfINFERENCE_FRAMES_PER_INFERENCE);
+                                           appconfAUDIO_PIPELINE_FRAME_ADVANCE,
+                                           appconfINFERENCE_SAMPLE_BLOCK_LENGTH);
 
     xTaskCreate((TaskFunction_t)wanson_engine_task,
                 "wanson_eng",
@@ -93,7 +93,7 @@ void wanson_engine_intertile_task_create(uint32_t priority)
 {
     samples_to_engine_stream_buf = xStreamBufferCreate(
                                            appconfINFERENCE_FRAME_BUFFER_MULT * appconfAUDIO_PIPELINE_FRAME_ADVANCE,
-                                           appconfINFERENCE_FRAMES_PER_INFERENCE);
+                                           appconfINFERENCE_SAMPLE_BLOCK_LENGTH);
 
     xTaskCreate((TaskFunction_t)wanson_engine_intertile_samples_in_task,
                 "inf_intertile_rx",

--- a/applications/ffd/src/app_conf.h
+++ b/applications/ffd/src/app_conf.h
@@ -135,10 +135,6 @@
 #define appconfMIC_SRC_DEFAULT     appconfMIC_SRC_MICS
 #endif
 
-#ifndef appconfDEBUG_RESOURCES
-#define appconfDEBUG_RESOURCES 0
-#endif
-
 /* I/O and interrupt cores for Tile 0 */
 /* Note, USB and SPI are mutually exclusive */
 #define appconfXUD_IO_CORE                      1 /* Must be kept off core 0 with the RTOS tick ISR */

--- a/applications/ffd/src/app_conf.h
+++ b/applications/ffd/src/app_conf.h
@@ -28,8 +28,8 @@
 #define appconfAUDIO_PIPELINE_FRAME_ADVANCE     MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME
 
 /* Intent Engine Configuration */
-#define appconfINFERENCE_FRAME_BUFFER_MULT      8       /* total buffer size is this value * MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME */
-#define appconfINFERENCE_FRAMES_PER_INFERENCE   480
+#define appconfINFERENCE_FRAME_BUFFER_MULT      (8*2)       /* total buffer size is this value * MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME */
+#define appconfINFERENCE_SAMPLE_BLOCK_LENGTH    240
 
 /* Enable inference engine */
 #ifndef appconfINFERENCE_ENABLED

--- a/applications/ffd/src/main.c
+++ b/applications/ffd/src/main.c
@@ -126,20 +126,8 @@ void startup_task(void *arg)
     led_heartbeat_create(appconfLED_HEARTBEAT_TASK_PRIORITY, NULL);
 #endif
 
-#if appconfDEBUG_RESOURCES
-#warning DEBUG_RESOURCES should not be set in final production applications!
-    char debug_string[2000];
-	for (;;) {
-        vTaskDelay(pdMS_TO_TICKS(5000));
-        memset(debug_string, 0x00, 2000);
-        vTaskGetRunTimeStats(debug_string);
-        rtos_printf("Tile[%d]\n%s\n", THIS_XCORE_TILE, debug_string);
-		rtos_printf("Tile[%d]:\n\tMinimum heap free: %d\n\tCurrent heap free: %d\n", THIS_XCORE_TILE, xPortGetMinimumEverFreeHeapSize(), xPortGetFreeHeapSize());
-	}
-#else
     vTaskSuspend(NULL);
     while(1){;} /* Trap */
-#endif
 }
 
 void vApplicationMinimalIdleHook(void)

--- a/applications/ffd/src/rtos_conf/FreeRTOSConfig.h
+++ b/applications/ffd/src/rtos_conf/FreeRTOSConfig.h
@@ -61,13 +61,8 @@ your application. */
 #define configUSE_CORE_INIT_HOOK                0
 
 /* Run time and task stats gathering related definitions. */
-#if appconfDEBUG_RESOURCES
-#define configGENERATE_RUN_TIME_STATS           1
-#define configUSE_TRACE_FACILITY                1
-#else
 #define configGENERATE_RUN_TIME_STATS           0
 #define configUSE_TRACE_FACILITY                0
-#endif
 #define configUSE_STATS_FORMATTING_FUNCTIONS    2 /* Setting to 2 does not include <stdio.h> in tasks.c */
 
 /* Co-routine related definitions. */


### PR DESCRIPTION
Removes run-time states from FFD

This PR also fixes "lost output samples for inference" messages during audio playback.  