### PR TITLE
Update ffva for explorer board

### DIFF
--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.cmake
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.cmake
@@ -20,6 +20,7 @@ target_link_libraries(sln_voice_app_ffva_board_support_xcore_ai_explorer
         rtos::drivers::general
         rtos::drivers::audio
         rtos::drivers::usb
+        rtos::drivers::dfu_image
         sln_voice::app::ffva::dac::aic3204
 )
 target_compile_options(sln_voice_app_ffva_board_support_xcore_ai_explorer

--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.c
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.c
@@ -29,3 +29,6 @@ rtos_i2c_slave_t *i2c_slave_ctx = &i2c_slave_ctx_s;
 
 static rtos_spi_slave_t spi_slave_ctx_s;
 rtos_spi_slave_t *spi_slave_ctx = &spi_slave_ctx_s;
+
+static rtos_dfu_image_t dfu_image_ctx_s;
+rtos_dfu_image_t *dfu_image_ctx = &dfu_image_ctx_s;

--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.h
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.h
@@ -11,6 +11,7 @@
 #include "rtos_i2s.h"
 #include "rtos_mic_array.h"
 #include "rtos_qspi_flash.h"
+#include "rtos_dfu_image.h"
 #include "rtos_spi_slave.h"
 
 /* Tile specifiers */
@@ -51,5 +52,6 @@ extern rtos_i2c_master_t *i2c_master_ctx;
 extern rtos_i2c_slave_t *i2c_slave_ctx;
 extern rtos_spi_slave_t *spi_slave_ctx;
 extern rtos_i2s_t *i2s_ctx;
+extern rtos_dfu_image_t *dfu_image_ctx;
 
 #endif /* DRIVER_INSTANCES_H_ */

--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/platform_conf.h
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/platform_conf.h
@@ -155,4 +155,56 @@
 #define appconfSPI_TASK_PRIORITY                (configMAX_PRIORITIES/2)
 #endif /* appconfSPI_TASK_PRIORITY */
 
+/*****************************************/
+/*  DFU Settings                         */
+/*****************************************/
+#define FL_QUADDEVICE_W25Q64JW \
+{ \
+    0,                      /* Just specify 0 as flash_id */ \
+    256,                    /* page size */ \
+    32768,                  /* num pages */ \
+    3,                      /* address size */ \
+    4,                      /* log2 clock divider */ \
+    0x9F,                   /* QSPI_RDID */ \
+    0,                      /* id dummy bytes */ \
+    3,                      /* id size in bytes */ \
+    0xEF6017,               /* device id (determined from xflash --spi-read-id 0x9F)*/ \
+    0x20,                   /* QSPI_SE */ \
+    4096,                   /* Sector erase is always 4KB */ \
+    0x06,                   /* QSPI_WREN */ \
+    0x04,                   /* QSPI_WRDI */ \
+    PROT_TYPE_SR,           /* Protection via SR */ \
+    {{0x18,0x00},{0,0}},    /* QSPI_SP, QSPI_SU */ \
+    0x02,                   /* QSPI_PP */ \
+    0xEB,                   /* QSPI_READ_FAST */ \
+    1,                      /* 1 read dummy byte */ \
+    SECTOR_LAYOUT_REGULAR,  /* mad sectors */ \
+    {4096,{0,{0}}},         /* regular sector sizes */ \
+    0x05,                   /* QSPI_RDSR */ \
+    0x01,                   /* QSPI_WRSR */ \
+    0x01,                   /* QSPI_WIP_BIT_MASK */ \
+}
+
+#ifndef BOARD_QSPI_SPEC
+/* Set up a default SPI spec if the app has not provided
+ * one explicitly.
+ * Note: The version checks only work in XTC Tools >15.2.0 
+ *       By default FL_QUADDEVICE_W25Q64JW is used 
+ */
+#ifdef __XMOS_XTC_VERSION_MAJOR__
+#if (__XMOS_XTC_VERSION_MAJOR__ == 15)      \
+    && (__XMOS_XTC_VERSION_MINOR__ >= 2)    \
+    && (__XMOS_XTC_VERSION_PATCH__ >= 0)
+/* In XTC >15.2.0 some SFDP support enables a generic 
+ * default spec
+ */
+#define BOARD_QSPI_SPEC     FL_QUADDEVICE_DEFAULT
+#else
+#define BOARD_QSPI_SPEC     FL_QUADDEVICE_W25Q64JW
+#endif
+#else
+#define BOARD_QSPI_SPEC     FL_QUADDEVICE_W25Q64JW
+#endif /* __XMOS_XTC_VERSION_MAJOR__ */
+#endif /* BOARD_QSPI_SPEC */
+
 #endif /* PLATFORM_CONF_H_ */

--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/platform_init.c
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/platform_init.c
@@ -17,16 +17,28 @@ static void mclk_init(chanend_t other_tile_c)
 #if ON_TILE(1) && !appconfEXTERNAL_MCLK
     app_pll_init();
 #endif
-#if ON_TILE(0)
-#if appconfUSB_ENABLED
-    adaptive_rate_adjust_init(other_tile_c);
-#endif
+#if appconfUSB_ENABLED && ON_TILE(USB_TILE_NO)
+    adaptive_rate_adjust_init();
 #endif
 }
 
 static void flash_init(void)
 {
 #if ON_TILE(FLASH_TILE_NO)
+    fl_QuadDeviceSpec qspi_spec = BOARD_QSPI_SPEC;
+    fl_QSPIPorts qspi_ports = {
+        .qspiCS = PORT_SQI_CS,
+        .qspiSCLK = PORT_SQI_SCLK,
+        .qspiSIO = PORT_SQI_SIO,
+        .qspiClkblk = FLASH_CLKBLK,
+    };
+
+    rtos_dfu_image_init(
+            dfu_image_ctx,
+            &qspi_ports,
+            &qspi_spec,
+            1);
+            
     qspi_flash_ctx->ctx.sfdp_skip = true;
     qspi_flash_ctx->ctx.sfdp_supported = false;
     qspi_flash_ctx->ctx.page_size_bytes = 256;

--- a/examples/ffva/bsp_config/XK_VOICE_L71/platform/platform_init.c
+++ b/examples/ffva/bsp_config/XK_VOICE_L71/platform/platform_init.c
@@ -18,7 +18,7 @@ static void mclk_init(chanend_t other_tile_c)
     app_pll_init();
 #endif
 #if appconfUSB_ENABLED && ON_TILE(USB_TILE_NO)
-    adaptive_rate_adjust_init(other_tile_c);
+    adaptive_rate_adjust_init();
 #endif
 }
 

--- a/examples/ffva/ffva.cmake
+++ b/examples/ffva/ffva.cmake
@@ -81,3 +81,9 @@ endif()
 #**********************
 include(${CMAKE_CURRENT_LIST_DIR}/ffva_int.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/ffva_ua.cmake)
+
+#**********************
+# Include FFVA Debug and Extension targets
+#**********************
+include(${CMAKE_CURRENT_LIST_DIR}/ffva_int_dev.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ffva_ua_dev.cmake)

--- a/examples/ffva/ffva_int_dev.cmake
+++ b/examples/ffva/ffva_int_dev.cmake
@@ -1,0 +1,96 @@
+
+set(FFVA_INT_COMPILE_DEFINITIONS
+${APP_COMPILE_DEFINITIONS}
+    appconfEXTERNAL_MCLK=1
+    appconfI2S_ENABLED=1
+    appconfUSB_ENABLED=0
+    appconfAEC_REF_DEFAULT=appconfAEC_REF_I2S
+    appconfI2S_MODE=appconfI2S_MODE_SLAVE
+    appconfI2S_AUDIO_SAMPLE_RATE=480000
+
+    ## VK Voice uses 12288000 for RPI integration, EXPLORER Board uses default 24576000
+    # MIC_ARRAY_CONFIG_MCLK_FREQ=12288000
+)
+
+foreach(FFVA_AP ${FFVA_PIPELINES_INT})
+#**********************
+# Tile Targets
+#**********************
+set(TARGET_NAME tile0_example_ffva_int_dev_${FFVA_AP})
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES})
+target_compile_definitions(${TARGET_NAME}
+    PUBLIC
+        ${FFVA_INT_COMPILE_DEFINITIONS}
+        THIS_XCORE_TILE=0
+)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME}
+    PUBLIC
+        ${APP_COMMON_LINK_LIBRARIES}
+        sln_voice::app::ffva::xcore_ai_explorer
+        sln_voice::app::ffva::ap::${FFVA_AP}
+)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+unset(TARGET_NAME)
+
+set(TARGET_NAME tile1_example_ffva_int_dev_${FFVA_AP})
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES})
+target_compile_definitions(${TARGET_NAME}
+    PUBLIC
+        ${FFVA_INT_COMPILE_DEFINITIONS}
+        THIS_XCORE_TILE=1
+)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME}
+    PUBLIC
+        ${APP_COMMON_LINK_LIBRARIES}
+        sln_voice::app::ffva::xcore_ai_explorer
+        sln_voice::app::ffva::ap::${FFVA_AP}
+)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+unset(TARGET_NAME)
+
+#**********************
+# Merge binaries
+#**********************
+merge_binaries(example_ffva_int_dev_${FFVA_AP} tile0_example_ffva_int_dev_${FFVA_AP} tile1_example_ffva_int_dev_${FFVA_AP} 1)
+
+#**********************
+# Create run and debug targets
+#**********************
+create_run_target(example_ffva_int_dev_${FFVA_AP})
+create_debug_target(example_ffva_int_dev_${FFVA_AP})
+
+#**********************
+# Filesystem support targets
+#**********************
+
+set(FATFS_CONTENTS_DIR ${CMAKE_CURRENT_LIST_DIR}/filesystem_support/fatmktmp)
+set(FATFS_FILE ${CMAKE_CURRENT_LIST_DIR}/filesystem_support/example_ffva_int_dev_${FFVA_AP}_fat.fs)
+add_custom_target(
+    example_ffva_int_dev_${FFVA_AP}_fat.fs ALL
+    COMMAND ${CMAKE_COMMAND} -E copy demo.txt ${FATFS_CONTENTS_DIR}/fs/demo.txt
+    COMMAND fatfs_mkimage --input=${FATFS_CONTENTS_DIR} --output=${FATFS_FILE}
+    COMMENT
+        "Create filesystem"
+    WORKING_DIRECTORY
+        ${CMAKE_CURRENT_LIST_DIR}/filesystem_support
+    VERBATIM
+)
+
+set_target_properties(example_ffva_int_dev_${FFVA_AP}_fat.fs PROPERTIES
+    ADDITIONAL_CLEAN_FILES "${FATFS_CONTENTS_DIR};${FATFS_FILE}"
+)
+
+create_filesystem_target(example_ffva_int_dev_${FFVA_AP})
+create_flash_app_target(
+    #[[ Target ]]                  example_ffva_int_dev_${FFVA_AP}
+    #[[ Boot Partition Size ]]     0x100000
+    #[[ Data Partition Contents ]] ${FATFS_FILE}
+    #[[ Dependencies ]]            make_fs_example_ffva_int_dev_${FFVA_AP}
+)
+endforeach()

--- a/examples/ffva/ffva_ua_dev.cmake
+++ b/examples/ffva/ffva_ua_dev.cmake
@@ -1,0 +1,112 @@
+
+option(DEBUG_FFVA_USB_MIC_INPUT        "Enable ffva usb mic input"  OFF)
+option(DEBUG_FFVA_USB_MIC_INPUT_PIPELINE_BYPASS  "Enable ffva usb mic input and audio pipeline bypass"  OFF)
+
+set(FFVA_UA_COMPILE_DEFINITIONS
+    ${APP_COMPILE_DEFINITIONS}
+    appconfI2S_ENABLED=1
+    appconfUSB_ENABLED=1
+    appconfAEC_REF_DEFAULT=appconfAEC_REF_USB
+    appconfI2S_MODE=appconfI2S_MODE_MASTER
+
+    MIC_ARRAY_CONFIG_MCLK_FREQ=24576000
+)
+
+if(DEBUG_FFVA_USB_MIC_INPUT)
+    list(APPEND FFVA_UA_COMPILE_DEFINITIONS appconfMIC_SRC_DEFAULT=appconfMIC_SRC_USB)
+    list(APPEND FFVA_UA_COMPILE_DEFINITIONS appconfUSB_AUDIO_MODE=appconfUSB_AUDIO_TESTING)
+endif()
+
+# a usb mic enabled build without the pipeline for sample rate conversion testing
+if(DEBUG_FFVA_USB_MIC_INPUT_PIPELINE_BYPASS)
+    list(APPEND FFVA_UA_COMPILE_DEFINITIONS appconfMIC_SRC_DEFAULT=appconfMIC_SRC_USB)
+    list(APPEND FFVA_UA_COMPILE_DEFINITIONS appconfUSB_AUDIO_MODE=appconfUSB_AUDIO_TESTING)
+    list(APPEND FFVA_UA_COMPILE_DEFINITIONS appconfPIPELINE_BYPASS=1)
+    list(APPEND FFVA_UA_COMPILE_DEFINITIONS appconfUSB_AUDIO_SAMPLE_RATE=48000)
+endif()
+
+query_tools_version()
+foreach(FFVA_AP ${FFVA_PIPELINES_UA})
+    #**********************
+    # Tile Targets
+    #**********************
+    set(TARGET_NAME tile0_example_ffva_ua_dev_${FFVA_AP})
+    add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+    target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES})
+    target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES})
+    target_compile_definitions(${TARGET_NAME}
+        PUBLIC
+            ${FFVA_UA_COMPILE_DEFINITIONS}
+            THIS_XCORE_TILE=0
+    )
+    target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS})
+    target_link_libraries(${TARGET_NAME}
+        PUBLIC
+            ${APP_COMMON_LINK_LIBRARIES}
+            sln_voice::app::ffva::xcore_ai_explorer
+            sln_voice::app::ffva::ap::${FFVA_AP}
+    )
+    target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+    unset(TARGET_NAME)
+
+    set(TARGET_NAME tile1_example_ffva_ua_dev_${FFVA_AP})
+    add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+    target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES})
+    target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES})
+    target_compile_definitions(${TARGET_NAME}
+        PUBLIC
+            ${FFVA_UA_COMPILE_DEFINITIONS}
+            THIS_XCORE_TILE=1
+    )
+    target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS})
+    target_link_libraries(${TARGET_NAME}
+        PUBLIC
+            ${APP_COMMON_LINK_LIBRARIES}
+            sln_voice::app::ffva::xcore_ai_explorer
+            sln_voice::app::ffva::ap::${FFVA_AP}
+    )
+    target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+    unset(TARGET_NAME)
+
+    #**********************
+    # Merge binaries
+    #**********************
+    merge_binaries(example_ffva_ua_dev_${FFVA_AP} tile0_example_ffva_ua_dev_${FFVA_AP} tile1_example_ffva_ua_dev_${FFVA_AP} 1)
+
+    #**********************
+    # Create run and debug targets
+    #**********************
+    create_run_target(example_ffva_ua_dev_${FFVA_AP})
+    create_debug_target(example_ffva_ua_dev_${FFVA_AP})
+    create_upgrade_img_target(example_ffva_ua_dev_${FFVA_AP} ${XTC_VERSION_MAJOR} ${XTC_VERSION_MINOR})
+
+    #**********************
+    # Filesystem support targets
+    #**********************
+
+    set(FATFS_CONTENTS_DIR ${CMAKE_CURRENT_LIST_DIR}/filesystem_support/fatmktmp)
+    set(FATFS_FILE ${CMAKE_CURRENT_LIST_DIR}/filesystem_support/example_ffva_ua_dev_${FFVA_AP}_fat.fs)
+    add_custom_target(
+        example_ffva_ua_dev_${FFVA_AP}_fat.fs ALL
+        COMMAND ${CMAKE_COMMAND} -E copy demo.txt ${FATFS_CONTENTS_DIR}/fs/demo.txt
+        COMMAND fatfs_mkimage --input=${FATFS_CONTENTS_DIR} --output=${FATFS_FILE}
+        COMMENT
+            "Create filesystem"
+        WORKING_DIRECTORY
+            ${CMAKE_CURRENT_LIST_DIR}/filesystem_support
+        VERBATIM
+    )
+
+    set_target_properties(example_ffva_ua_dev_${FFVA_AP}_fat.fs PROPERTIES
+        ADDITIONAL_CLEAN_FILES "${FATFS_CONTENTS_DIR};${FATFS_FILE}"
+    )
+
+    create_filesystem_target(example_ffva_ua_dev_${FFVA_AP})
+    create_flash_app_target(
+        #[[ Target ]]                  example_ffva_ua_dev_${FFVA_AP}
+        #[[ Boot Partition Size ]]     0x100000
+        #[[ Data Partition Contents ]] ${FATFS_FILE}
+        #[[ Dependencies ]]            make_fs_example_ffva_ua_dev_${FFVA_AP}
+    )
+
+endforeach()

--- a/examples/ffva/src/usb/adaptive_rate_adjust.c
+++ b/examples/ffva/src/usb/adaptive_rate_adjust.c
@@ -131,9 +131,8 @@ bool tud_xcore_sof_cb(uint8_t rhport)
     return false;
 }
 
-void adaptive_rate_adjust_init(chanend_t other_tile_c)
+void adaptive_rate_adjust_init(void)
 {
-
     xTaskCreate((TaskFunction_t) usb_adaptive_clk_manager,
                 "usb_adpt_mgr",
                 RTOS_THREAD_STACK_SIZE(usb_adaptive_clk_manager),

--- a/examples/ffva/src/usb/adaptive_rate_adjust.h
+++ b/examples/ffva/src/usb/adaptive_rate_adjust.h
@@ -41,6 +41,6 @@
 #define Q9(f)  (int)((signed long long)((f) * ((unsigned long long)1 << (9+20)) + (1<<19)) >> 20)
 #define Q8(f)  (int)((signed long long)((f) * ((unsigned long long)1 << (8+20)) + (1<<19)) >> 20)
 
-void adaptive_rate_adjust_init(chanend_t other_tile_c);
+void adaptive_rate_adjust_init(void);
 
 #endif /* ADAPTIVE_RATE_ADJUST_H_ */

--- a/tools/ci/build_misc_examples.sh
+++ b/tools/ci/build_misc_examples.sh
@@ -20,11 +20,17 @@ fi
 # setup configurations
 # row format is: "name app_target run_fs_target BOARD toolchain"
 examples=(
-    "audio_mux               example_audio_mux               No   XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
-    "ffd                     example_ffd                     Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
-    "ffva_int_adec_altarch   example_ffva_int_adec_altarch   Yes  XK_VOICE_L71        xmos_cmake_toolchain/xs3a.cmake"
-    "ffva_ua_adec_altarch    example_ffva_ua_adec_altarch    Yes  XK_VOICE_L71        xmos_cmake_toolchain/xs3a.cmake"
-    "ffva_ua_fixed_delay     example_ffva_ua_fixed_delay     Yes  XK_VOICE_L71        xmos_cmake_toolchain/xs3a.cmake"
+    "audio_mux                 example_audio_mux                No   XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
+    "ffd                       example_ffd_dev                  Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_int_adec_altarch     example_ffva_int_adec_altarch    Yes  XK_VOICE_L71        xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_ua_adec_altarch      example_ffva_ua_adec_altarch     Yes  XK_VOICE_L71        xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_ua_fixed_delay       example_ffva_ua_fixed_delay      Yes  XK_VOICE_L71        xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_int_dev_fixed_delay  example_ffva_int_dev_fixed_delay Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_int_dev_adec         example_ffva_int_dev_adec        Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_int_dev_adec_altarch example_ffva_int_adec_altarch    Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_ua_dev_fixed_delay   example_ffva_ua_dev_fixed_delay  Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_ua_dev_adec          example_ffva_ua_dev_adec         Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
+    "ffva_ua_dev_adec_altarch  example_ffva_ua_adec_altarch     Yes  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake"
 )
 
 # perform builds


### PR DESCRIPTION
Closes #148 

Not added to CI testing at this time.  Verified locally.

Note, INT requires an external MCLK.  On the VOICE board this is received from an RPI.  Since the explorer board does not have one, the user must supply one via the header pins.  INT was verified with an INT configuration where MCLK was not external, and generated locally via the app pll.