### PR TITLE
Add core affinity to flash driver

### DIFF
--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/platform_start.c
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/platform/platform_start.c
@@ -39,7 +39,9 @@ static void gpio_start(void)
 static void flash_start(void)
 {
 #if ON_TILE(FLASH_TILE_NO)
+    uint32_t flash_core_map = ~((1 << appconfUSB_INTERRUPT_CORE) | (1 << appconfUSB_SOF_INTERRUPT_CORE));
     rtos_qspi_flash_start(qspi_flash_ctx, appconfQSPI_FLASH_TASK_PRIORITY);
+    rtos_qspi_flash_op_core_affinity_set(qspi_flash_ctx, flash_core_map);
 #endif
 }
 

--- a/examples/ffva/bsp_config/XK_VOICE_L71/platform/platform_start.c
+++ b/examples/ffva/bsp_config/XK_VOICE_L71/platform/platform_start.c
@@ -39,7 +39,9 @@ static void gpio_start(void)
 static void flash_start(void)
 {
 #if ON_TILE(FLASH_TILE_NO)
+    uint32_t flash_core_map = ~((1 << appconfUSB_INTERRUPT_CORE) | (1 << appconfUSB_SOF_INTERRUPT_CORE));
     rtos_qspi_flash_start(qspi_flash_ctx, appconfQSPI_FLASH_TASK_PRIORITY);
+    rtos_qspi_flash_op_core_affinity_set(qspi_flash_ctx, flash_core_map);
 #endif
 }
 


### PR DESCRIPTION
This prevents collision between the QSPI operation, which disabled interrupts, and the lib_xud ISRs which would result in spurious failures of the DFU test.