### PR TITLE
Move Sensory ASR stackfunction from app to port

### DIFF
--- a/examples/low_power_ffd/low_power_ffd.cmake
+++ b/examples/low_power_ffd/low_power_ffd.cmake
@@ -25,6 +25,7 @@ set(APP_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/src/intent_handler
     ${CMAKE_CURRENT_LIST_DIR}/src/intent_handler/audio_response
     ${CMAKE_CURRENT_LIST_DIR}/src/power
+    ${CMAKE_CURRENT_LIST_DIR}/src/wakeword
 )
 set(RTOS_CONF_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/src/rtos_conf

--- a/examples/low_power_ffd/src/app_conf.h
+++ b/examples/low_power_ffd/src/app_conf.h
@@ -21,6 +21,7 @@
 #define AUDIO_PIPELINE_TILE_NO                  MICARRAY_TILE_NO
 #define ASR_TILE_NO                             FLASH_TILE_NO
 #define FS_TILE_NO                              FLASH_TILE_NO
+#define WAKEWORD_TILE_NO                        AUDIO_PIPELINE_TILE_NO
 
 /* Sensory specific settings */
 #if ON_TILE(ASR_TILE_NO)
@@ -80,7 +81,7 @@
 #endif
 
 #ifndef appconfI2S_ENABLED
-#define appconfI2S_ENABLED                      1
+#define appconfI2S_ENABLED                      0
 #endif
 
 /* Enable/disable the use of a ring buffer between the audio pipeline and the

--- a/examples/low_power_ffd/src/wakeword/wake_word_engine.c
+++ b/examples/low_power_ffd/src/wakeword/wake_word_engine.c
@@ -69,12 +69,7 @@ wakeword_result_t wake_word_engine_handler(asr_sample_t *buf, size_t num_frames)
     }
 
     if (asr_error == ASR_EVALUATION_EXPIRED) {
-<<<<<<< HEAD:examples/low_power_ffd/src/wakeword/wake_word_engine.c
         retval = WAKEWORD_ERROR;
-=======
-        power_control_halt();
-        power_state_set(POWER_STATE_FULL);
->>>>>>> develop:examples/low_power_ffd/src/intent_engine/wake_word_engine.c
     } else if (asr_error != ASR_OK) {
         debug_printf("ASR error on tile %d: %d\n", THIS_XCORE_TILE, asr_error);
     } else if (IS_WAKE_WORD(asr_result.id)) {

--- a/examples/low_power_ffd/src/wakeword/wake_word_engine.h
+++ b/examples/low_power_ffd/src/wakeword/wake_word_engine.h
@@ -9,9 +9,13 @@
 #include "app_conf.h"
 #include "asr.h"
 
-#if ON_TILE(AUDIO_PIPELINE_TILE_NO)
+typedef enum {
+    WAKEWORD_FOUND,
+    WAKEWORD_NOT_FOUND,
+    WAKEWORD_ERROR
+} wakeword_result_t;
+
 void wake_word_engine_init(void);
-void wake_word_engine_handler(asr_sample_t *buf, size_t num_frames);
-#endif /* ON_TILE(AUDIO_PIPELINE_TILE_NO) */
+wakeword_result_t wake_word_engine_handler(asr_sample_t *buf, size_t num_frames);
 
 #endif /* WAKE_WORD_ENGINE_H_ */

--- a/modules/asr/sensory/sensory_asr.c
+++ b/modules/asr/sensory/sensory_asr.c
@@ -45,6 +45,7 @@ static BOOL xcore_is_flash(const void * ptr)
     else return FALSE;
 }
 
+#pragma stackfunction 50
 asr_port_t asr_init(int32_t *model, int32_t *grammar, devmem_manager_t *devmem)
 {
     errors_t error;
@@ -111,6 +112,7 @@ asr_port_t asr_init(int32_t *model, int32_t *grammar, devmem_manager_t *devmem)
     return (asr_port_t) &sensory_asr;
 }
 
+#pragma stackfunction 250
 asr_error_t asr_process(asr_port_t *ctx, int16_t *audio_buf, size_t buf_len)
 {
     xassert(ctx);


### PR DESCRIPTION
This enables the ASR port to be used elsewhere and simplifies the ffd_lp app.

Also removes the power control dependency from sensory wakeword engine to make the wakeword engine portable.