### PR TITLE
Fix EP1 IN output data size calculation

### DIFF
--- a/examples/ffva/src/usb/usb_audio.c
+++ b/examples/ffva/src/usb/usb_audio.c
@@ -636,7 +636,7 @@ bool tud_audio_tx_done_pre_load_cb(uint8_t rhport,
      * This assumes (as with XUA_lite) that the host sends the same number of samples for each channel.
      * This also assumes that TX and RX rates are the same, which is an assumption made elsewhere.
      * This finally assumes that at nominal rate,
-     *     AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER == prev_n_bytes_received / CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX
+     *     AUDIO_FRAMES_PER_USB_FRAME == prev_n_bytes_received / (CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX * sizeof(samp_t))
      */
     if (host_streaming_out && (0 != prev_n_bytes_received))
     {

--- a/examples/ffva/src/usb/usb_audio.c
+++ b/examples/ffva/src/usb/usb_audio.c
@@ -644,7 +644,7 @@ bool tud_audio_tx_done_pre_load_cb(uint8_t rhport,
     }
     else
     {
-        tx_size_bytes = sizeof(samp_t) * (AUDIO_FRAMES_PER_USB_FRAME / RATE_MULTIPLIER) * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX;
+        tx_size_bytes = sizeof(samp_t) * AUDIO_FRAMES_PER_USB_FRAME * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX;
     }
     tx_size_frames = tx_size_bytes / (sizeof(samp_t) * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX);
 


### PR DESCRIPTION
https://xmosjira.atlassian.net/browse/AP-155

This issue shows up as either noisy data in the device USB output or the ch0 and ch1 outputs look like they've been swapped.
This only happens when recording the very first time after enumeration. If I stop and restart recording, the problem always gets fixed.

On looking at the Beagle trace of the first recording after enumeration, I notice that before the EP1 OUT transfers start, the EP1 IN size is 128 bytes, which is incorrect. The expected nominal size is 384 bytes. The EP1 IN size becomes 384 only after the first EP1 OUT transfer, since once OUT transfers start the OUT size is copied to IN in the USB driver.

![Screenshot 2023-09-26 at 10 45 56](https://github.com/xmos/sln_voice/assets/38428600/44782a7e-86c4-4639-9304-f034b0568375)

The 128 bytes size is wrongly calculated in tud_audio_rx_done_post_read_cb(). If 128 bytes is the size to be sent over USB, the data size to be read from the pipeline output is then calculated as 128/3 = 42 (16KHz pipeline, 48KHz USB), which is not a multiple of 4. So for 32bit USB cases, this ends up with the interleaved channel samples getting out of sync.

This can be seen in the trace below, where the 2nd channel is always 0x12345678. The 128 bytes frames look like this:

![Screenshot 2023-09-26 at 10 54 49](https://github.com/xmos/sln_voice/assets/38428600/4a73cc72-8cee-4dc6-a545-f1e6cae178da)

And the 384 bytes frame look like this:

![Screenshot 2023-09-26 at 10 55 53](https://github.com/xmos/sln_voice/assets/38428600/1d0d8174-5eb2-453c-8f57-d7b38cbd9459)

We can see, how the 384 bytes frame wrongly starts with 0x1234