### PR TITLE
Use raw xrun / xgdb over custom targets in docs

### DIFF
--- a/doc/programming_guide/asr/deploying/linux_macos.rst
+++ b/doc/programming_guide/asr/deploying/linux_macos.rst
@@ -64,7 +64,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    make run_example_asr
+    xrun --xscope-realtime --xscope-port localhost:12345 example_asr.xe
 
 In a second console, run the following command in the ``examples/speech_recognition`` folder to run the host server:
 

--- a/doc/programming_guide/asr/deploying/native_windows.rst
+++ b/doc/programming_guide/asr/deploying/native_windows.rst
@@ -82,7 +82,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    ninja run_example_asr
+    xrun --xscope-realtime --xscope-port localhost:12345 example_asr.xe
 
 In a second console, run the following command in the ``examples/speech_recognition`` folder to run the host server:
 

--- a/doc/programming_guide/asrc/overview.rst
+++ b/doc/programming_guide/asrc/overview.rst
@@ -149,13 +149,14 @@ To run the app, either xrun or xflash can be used. Connect the XK-VOICE-L71 boar
 
    $ xrun example_asrc_demo.xe
 
-or
+Optionally, xrun ``--xscope`` can be used to provide real-time debug output.
+
+or to flash the application so that it always boots after a power cycle:
 
 ::
 
    $ xflash example_asrc_demo.xe
 
-Optionally, xrun ``--xscope`` can be used to provide debug output.
 
 Operation
 =========

--- a/doc/programming_guide/asrc/overview.rst
+++ b/doc/programming_guide/asrc/overview.rst
@@ -143,13 +143,12 @@ Following initial ``cmake`` build, for subsequent builds, as long as new source 
 Running the app
 ===============
 
-To run the app, either xrun or xflash can be used. Connect the XK-VOICE-L71 board to the host and type:
+To run the app, either xrun or xflash can be used. Connect the XK-VOICE-L71 board to the host and type the following
+to run with real-time debug output enabled:
 
 ::
 
-   $ xrun example_asrc_demo.xe
-
-Optionally, xrun ``--xscope`` can be used to provide real-time debug output.
+   $ xrun --xscope example_asrc_demo.xe
 
 or to flash the application so that it always boots after a power cycle:
 

--- a/doc/programming_guide/ffd/deploying/linux_macos.rst
+++ b/doc/programming_guide/ffd/deploying/linux_macos.rst
@@ -57,7 +57,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    xrun example_ffd.xe
+    xrun --xscope example_ffd.xe
 
 Debugging the Firmware
 ======================

--- a/doc/programming_guide/ffd/deploying/linux_macos.rst
+++ b/doc/programming_guide/ffd/deploying/linux_macos.rst
@@ -57,7 +57,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    make run_example_ffd
+    xrun example_ffd.xe
 
 Debugging the Firmware
 ======================
@@ -67,4 +67,4 @@ To debug with xgdb, from the build folder run:
 
 .. code-block:: console
 
-    make debug_example_ffd
+    xgdb -ex "connect --xscope" -ex "run" example_ffd.xe

--- a/doc/programming_guide/ffd/deploying/native_windows.rst
+++ b/doc/programming_guide/ffd/deploying/native_windows.rst
@@ -72,7 +72,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    xrun example_ffd.xe
+    xrun --xscope example_ffd.xe
 
 Debugging the Firmware
 ======================

--- a/doc/programming_guide/ffd/deploying/native_windows.rst
+++ b/doc/programming_guide/ffd/deploying/native_windows.rst
@@ -72,7 +72,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    ninja run_example_ffd
+    xrun example_ffd.xe
 
 Debugging the Firmware
 ======================
@@ -81,4 +81,4 @@ To debug with xgdb, from the build folder run:
 
 .. code-block:: console
 
-    ninja debug_example_ffd
+    xgdb -ex "connect --xscope" -ex "run" example_ffd.xe

--- a/doc/programming_guide/ffva/deploying/linux_macos.rst
+++ b/doc/programming_guide/ffva/deploying/linux_macos.rst
@@ -63,8 +63,8 @@ From the build folder run:
 
 .. code-block:: console
 
-    make run_example_ffva_int_fixed_delay
-    make run_example_ffva_ua_adec_altarch
+    xrun example_ffva_int_fixed_delay.xe
+    xrun example_ffva_ua_adec_altarch.xe
 
 Upgrading the Firmware
 ======================
@@ -139,5 +139,5 @@ To debug with xgdb, from the build folder run:
 
 .. code-block:: console
 
-    make debug_example_int_adec
-    make debug_example_ua_adec
+    xgdb -ex "connect --xscope" -ex "run" example_ffva_int_fixed_delay.xe
+    xgdb -ex "connect --xscope" -ex "run" example_ffva_ua_adec_altarch.xe

--- a/doc/programming_guide/ffva/deploying/linux_macos.rst
+++ b/doc/programming_guide/ffva/deploying/linux_macos.rst
@@ -63,8 +63,8 @@ From the build folder run:
 
 .. code-block:: console
 
-    xrun example_ffva_int_fixed_delay.xe
-    xrun example_ffva_ua_adec_altarch.xe
+    xrun --xscope example_ffva_int_fixed_delay.xe
+    xrun --xscope example_ffva_ua_adec_altarch.xe
 
 Upgrading the Firmware
 ======================

--- a/doc/programming_guide/ffva/deploying/native_windows.rst
+++ b/doc/programming_guide/ffva/deploying/native_windows.rst
@@ -80,8 +80,8 @@ From the build folder run:
 
 .. code-block:: console
 
-    xrun example_ffva_int_fixed_delay.xe
-    xrun example_ffva_ua_adec_altarch.xe
+    xrun --xscope example_ffva_int_fixed_delay.xe
+    xrun --xscope example_ffva_ua_adec_altarch.xe
 
 Upgrading the Firmware
 ======================

--- a/doc/programming_guide/ffva/deploying/native_windows.rst
+++ b/doc/programming_guide/ffva/deploying/native_windows.rst
@@ -80,8 +80,8 @@ From the build folder run:
 
 .. code-block:: console
 
-    ninja run_example_ffva_int_fixed_delay
-    ninja run_example_ffva_ua_adec_altarch
+    xrun example_ffva_int_fixed_delay.xe
+    xrun example_ffva_ua_adec_altarch.xe
 
 Upgrading the Firmware
 ======================
@@ -156,5 +156,5 @@ To debug with xgdb, from the build folder run:
 
 .. code-block:: console
 
-    ninja debug_example_int_adec
-    ninja debug_example_ua_adec
+    xgdb -ex "connect --xscope" -ex "run" example_ffva_int_fixed_delay.xe
+    xgdb -ex "connect --xscope" -ex "run" example_ffva_ua_adec_altarch.xe

--- a/doc/programming_guide/low_power_ffd/deploying/linux_macos.rst
+++ b/doc/programming_guide/low_power_ffd/deploying/linux_macos.rst
@@ -57,7 +57,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    make run_example_low_power_ffd
+    xrun example_low_power_ffd.xe
 
 Debugging the Firmware
 ======================
@@ -66,6 +66,6 @@ To debug with xgdb, from the build folder run:
 
 .. code-block:: console
 
-    make debug_example_low_power_ffd
+    xgdb -ex "connect --xscope" -ex "run" example_low_power_ffd.xe
 
 |newpage|

--- a/doc/programming_guide/low_power_ffd/deploying/linux_macos.rst
+++ b/doc/programming_guide/low_power_ffd/deploying/linux_macos.rst
@@ -57,7 +57,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    xrun example_low_power_ffd.xe
+    xrun --xscope example_low_power_ffd.xe
 
 Debugging the Firmware
 ======================

--- a/doc/programming_guide/low_power_ffd/deploying/native_windows.rst
+++ b/doc/programming_guide/low_power_ffd/deploying/native_windows.rst
@@ -77,7 +77,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    xrun example_low_power_ffd.xe
+    xrun --xscope example_low_power_ffd.xe
 
 Debugging the Firmware
 ======================

--- a/doc/programming_guide/low_power_ffd/deploying/native_windows.rst
+++ b/doc/programming_guide/low_power_ffd/deploying/native_windows.rst
@@ -77,7 +77,7 @@ From the build folder run:
 
 .. code-block:: console
 
-    ninja run_example_low_power_ffd
+    xrun example_low_power_ffd.xe
 
 Debugging the Firmware
 ======================
@@ -86,6 +86,6 @@ To debug with xgdb, from the build folder run:
 
 .. code-block:: console
 
-    ninja debug_example_low_power_ffd
+    xgdb -ex "connect --xscope" -ex "run" example_low_power_ffd.xe
 
 |newpage|


### PR DESCRIPTION
I didn't update the flash targets - the reason is some are quite complex and contain magic numbers and scripts inside the makefile. For the first time user this may be a bit much so I think the make target helps in this case - the commands when run are at high verbosity so the underlying mechanisms can be seen.