### PR TITLE
Update empty pipeline in set of pipelines with reference audio

### DIFF
--- a/modules/audio_pipelines/reference/CMakeLists.txt
+++ b/modules/audio_pipelines/reference/CMakeLists.txt
@@ -1,5 +1,5 @@
 ##******************************************
-## Create fixed_delay AEC+IC+NS+AGC 
+## Create fixed_delay AEC+IC+NS+AGC
 ##   2 mic input channels
 #    2 reference input channels
 ##******************************************
@@ -30,7 +30,7 @@ target_link_libraries(fixed_delay_aec_ic_ns_agc_2mic_2ref
 )
 
 ##******************************************
-## Create ADEC "prevarch" AEC+IC+NS+AGC 
+## Create ADEC "prevarch" AEC+IC+NS+AGC
 ##   2 mic input channels
 #    2 reference input channels
 ##******************************************
@@ -66,7 +66,7 @@ target_link_libraries(adec_aec_ic_ns_agc_2mic_2ref
 )
 
 ##******************************************
-## Create ADEC altarch AEC+IC+NS+AGC 
+## Create ADEC altarch AEC+IC+NS+AGC
 ##   2 mic input channels
 #    2 reference input channels
 ##******************************************
@@ -108,7 +108,8 @@ target_link_libraries(adec_altarch_aec_ic_ns_agc_2mic_2ref
 add_library(empty_2mic_2ref INTERFACE)
 target_sources(empty_2mic_2ref
     INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/empty/audio_pipeline.c
+        ${CMAKE_CURRENT_LIST_DIR}/empty/audio_pipeline_t0.c
+        ${CMAKE_CURRENT_LIST_DIR}/empty/audio_pipeline_t1.c
 )
 target_include_directories(empty_2mic_2ref
     INTERFACE

--- a/modules/audio_pipelines/reference/empty/audio_pipeline_dsp.h
+++ b/modules/audio_pipelines/reference/empty/audio_pipeline_dsp.h
@@ -1,0 +1,20 @@
+// Copyright 2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef AUDIO_PIPELINE_DSP_H_
+#define AUDIO_PIPELINE_DSP_H_
+
+#include <stdint.h>
+#include "app_conf.h"
+
+
+/* Note: Changing the order here will effect the channel order for
+ * audio_pipeline_input() and audio_pipeline_output()
+ */
+typedef struct {
+    int32_t samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
+    int32_t aec_reference_audio_samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
+    int32_t mic_samples_passthrough[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
+} frame_data_t;
+
+#endif /* AUDIO_PIPELINE_DSP_H_ */

--- a/modules/audio_pipelines/reference/empty/audio_pipeline_t0.c
+++ b/modules/audio_pipelines/reference/empty/audio_pipeline_t0.c
@@ -1,0 +1,100 @@
+// Copyright 2022-2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* STD headers */
+#include <string.h>
+#include <stdint.h>
+#include <xcore/hwtimer.h>
+
+/* FreeRTOS headers */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "timers.h"
+#include "queue.h"
+#include "stream_buffer.h"
+
+/* Library headers */
+#include "generic_pipeline.h"
+
+/* App headers */
+#include "app_conf.h"
+#include "audio_pipeline.h"
+#include "audio_pipeline_dsp.h"
+
+#if appconfAUDIO_PIPELINE_FRAME_ADVANCE != 240
+#error This pipeline is only configured for 240 frame advance
+#endif
+
+#if ON_TILE(0)
+
+static void *audio_pipeline_input_i(void *input_app_data)
+{
+    frame_data_t *frame_data;
+
+    frame_data = pvPortMalloc(sizeof(frame_data_t));
+    memset(frame_data, 0x00, sizeof(frame_data_t));
+
+    size_t bytes_received = 0;
+    bytes_received = rtos_intertile_rx_len(
+            intertile_ctx,
+            appconfAUDIOPIPELINE_PORT,
+            portMAX_DELAY);
+
+    xassert(bytes_received == sizeof(frame_data_t));
+
+    rtos_intertile_rx_data(
+            intertile_ctx,
+            frame_data,
+            bytes_received);
+
+    return frame_data;
+}
+
+static int audio_pipeline_output_i(frame_data_t *frame_data,
+                                   void *output_app_data)
+{
+    return audio_pipeline_output(output_app_data,
+                               (int32_t **)frame_data->samples,
+                               6,
+                               appconfAUDIO_PIPELINE_FRAME_ADVANCE);
+}
+
+void empty_stage(void)
+{
+    ;
+}
+
+static void initialize_pipeline_stages(void)
+{
+    ;
+}
+
+void audio_pipeline_init(
+    void *input_app_data,
+    void *output_app_data)
+{
+    const int stage_count = 2;
+
+    const pipeline_stage_t stages[] = {
+        (pipeline_stage_t)empty_stage,
+        (pipeline_stage_t)empty_stage,
+    };
+
+    const configSTACK_DEPTH_TYPE stage_stack_sizes[] = {
+        configMINIMAL_STACK_SIZE + RTOS_THREAD_STACK_SIZE(empty_stage) + RTOS_THREAD_STACK_SIZE(audio_pipeline_input_i),
+        configMINIMAL_STACK_SIZE + RTOS_THREAD_STACK_SIZE(empty_stage) + RTOS_THREAD_STACK_SIZE(audio_pipeline_output_i),
+    };
+
+    initialize_pipeline_stages();
+
+    generic_pipeline_init((pipeline_input_t)audio_pipeline_input_i,
+                        (pipeline_output_t)audio_pipeline_output_i,
+                        input_app_data,
+                        output_app_data,
+                        stages,
+                        (const size_t*) stage_stack_sizes,
+                        appconfAUDIO_PIPELINE_TASK_PRIORITY,
+                        stage_count);
+}
+
+#endif /* ON_TILE(0)*/

--- a/modules/audio_pipelines/reference/empty/audio_pipeline_t1.c
+++ b/modules/audio_pipelines/reference/empty/audio_pipeline_t1.c
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 XMOS LIMITED.
+// Copyright 2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /* STD headers */
@@ -19,36 +19,26 @@
 /* App headers */
 #include "app_conf.h"
 #include "audio_pipeline.h"
+#include "audio_pipeline_dsp.h"
 
 #if appconfAUDIO_PIPELINE_FRAME_ADVANCE != 240
 #error This pipeline is only configured for 240 frame advance
 #endif
 
-typedef struct {
-    int32_t samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
-    int32_t aec_reference_audio_samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
-    int32_t mic_samples_passthrough[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
-} frame_data_t;
+#if ON_TILE(1)
 
 static void *audio_pipeline_input_i(void *input_app_data)
 {
     frame_data_t *frame_data;
-
     frame_data = pvPortMalloc(sizeof(frame_data_t));
     memset(frame_data, 0x00, sizeof(frame_data_t));
 
-    size_t bytes_received = 0;
-    bytes_received = rtos_intertile_rx_len(
-            intertile_ctx,
-            appconfAUDIOPIPELINE_PORT,
-            portMAX_DELAY);
+    audio_pipeline_input(input_app_data,
+                       (int32_t **)frame_data->aec_reference_audio_samples,
+                       4,
+                       appconfAUDIO_PIPELINE_FRAME_ADVANCE);
 
-    xassert(bytes_received == sizeof(frame_data_t));
-
-    rtos_intertile_rx_data(
-            intertile_ctx,
-            frame_data,
-            bytes_received);
+    memcpy(frame_data->samples, frame_data->mic_samples_passthrough, sizeof(frame_data->samples));
 
     return frame_data;
 }
@@ -56,10 +46,13 @@ static void *audio_pipeline_input_i(void *input_app_data)
 static int audio_pipeline_output_i(frame_data_t *frame_data,
                                    void *output_app_data)
 {
-    return audio_pipeline_output(output_app_data,
-                               (int32_t **)frame_data->samples,
-                               6,
-                               appconfAUDIO_PIPELINE_FRAME_ADVANCE);
+
+    rtos_intertile_tx(intertile_ctx,
+                      appconfAUDIOPIPELINE_PORT,
+                      frame_data,
+                      sizeof(frame_data_t));
+
+    return AUDIO_PIPELINE_FREE_FRAME;
 }
 
 void empty_stage(void)
@@ -77,7 +70,6 @@ void audio_pipeline_init(
     void *output_app_data)
 {
     const int stage_count = 2;
-
     const pipeline_stage_t stages[] = {
         (pipeline_stage_t)empty_stage,
         (pipeline_stage_t)empty_stage,
@@ -98,4 +90,6 @@ void audio_pipeline_init(
                         (const size_t*) stage_stack_sizes,
                         appconfAUDIO_PIPELINE_TASK_PRIORITY,
                         stage_count);
+
 }
+#endif /* ON_TILE(1)*/


### PR DESCRIPTION
The `audio_pipeline.c` file in the empty pipeline has been split into a `_t0` and a `_t1` file. The content of the input and output functions have been updated so that they match the same behaviour in the other pipelines.

I built an empty pipeline example by doing:

```
cmake -B build -G Ninja --toolchain xmos_cmake_toolchain/xs3a.cmake  -DENABLE_ALL_FFVA_PIPELINES=1
cd build 
ninja example_ffva_int_cyberon_empty
```

and I tested by checking that I can record audio and trigger the intent engine by saying "Hello XMOS".