### PR TITLE
Remove QE bit, QE register and flash type information from XN files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ XCORE-VOICE change log
   * ADDED: Support for DFU over I2C for FFVA INT example.
   * CHANGED: Updated submodule fwk_rtos to version 3.1.0 from 3.0.5.
   * ADDED: lib_sw_pll submodule v1.1.0.
-  * REMOVED: flash settings in .xn files, as they are not used by XMOS Tools
-    15.2.x.
+  * REMOVED: flash settings in .xn files, as they are not required by XMOS
+    Tools 15.2.x.
 
 2.2.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ XCORE-VOICE change log
   * ADDED: Support for DFU over I2C for FFVA INT example.
   * CHANGED: Updated submodule fwk_rtos to version 3.1.0 from 3.0.5.
   * ADDED: lib_sw_pll submodule v1.1.0.
+  * REMOVED: flash settings in .xn files, as they are not used by XMOS Tools
+    15.2.x.
 
 2.2.0
 -----

--- a/examples/ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/examples/ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="32768">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="32768">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/examples/ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/examples/ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -81,8 +81,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <!-- <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/> -->
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.xn
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.xn
@@ -74,7 +74,7 @@
             <Port Location="XS1_PORT_1A" Name="PORT_I2S_DAC_DATA"/>
             <Port Location="XS1_PORT_1N" Name="PORT_I2S_ADC_DATA"/>
             <Port Location="XS1_PORT_4A" Name="PORT_CODEC_RST_N"/>
-            
+
             <!-- I2C Slave ports -->
             <Port Location="XS1_PORT_1M" Name="PORT_I2C_SLAVE_SCL"/>
             <Port Location="XS1_PORT_1O" Name="PORT_I2C_SLAVE_SDA"/>
@@ -101,8 +101,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/>
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/examples/ffva/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.xn
+++ b/examples/ffva/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.xn
@@ -97,7 +97,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/examples/ffva/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/examples/ffva/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -81,7 +81,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="32768">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="32768">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/examples/ffva/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/examples/ffva/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -85,8 +85,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <!-- <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/> -->
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/examples/low_power_ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/examples/low_power_ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="32768">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="32768">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/examples/low_power_ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/examples/low_power_ffd/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -81,8 +81,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <!-- <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/> -->
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/examples/mic_aggregator/src/XCORE-AI-EXPLORER.xn
+++ b/examples/mic_aggregator/src/XCORE-AI-EXPLORER.xn
@@ -48,13 +48,13 @@
             <Port Location="XS1_PORT_1B" Name="PORT_SQI_CS"/>
             <Port Location="XS1_PORT_1C" Name="PORT_SQI_SCLK"/>
             <Port Location="XS1_PORT_4B" Name="PORT_SQI_SIO"/>
-            
+
             <Port Location="XS1_PORT_1N"  Name="PORT_I2C_SCL"/>
             <Port Location="XS1_PORT_1O"  Name="PORT_I2C_SDA"/>
-            
+
             <Port Location="XS1_PORT_4C" Name="PORT_LEDS"/>
             <Port Location="XS1_PORT_4D" Name="PORT_BUTTONS"/>
-            
+
             <Port Location="XS1_PORT_1I"  Name="WIFI_WIRQ"/>
             <Port Location="XS1_PORT_1J"  Name="WIFI_MOSI"/>
             <Port Location="XS1_PORT_4E"  Name="WIFI_WUP_RST_N"/>
@@ -111,8 +111,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/>
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/examples/speech_recognition/XCORE-AI-EXPLORER.xn
+++ b/examples/speech_recognition/XCORE-AI-EXPLORER.xn
@@ -97,7 +97,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="32768">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="32768">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/examples/speech_recognition/XCORE-AI-EXPLORER.xn
+++ b/examples/speech_recognition/XCORE-AI-EXPLORER.xn
@@ -74,7 +74,7 @@
             <Port Location="XS1_PORT_1A" Name="PORT_I2S_DAC_DATA"/>
             <Port Location="XS1_PORT_1N" Name="PORT_I2S_ADC_DATA"/>
             <Port Location="XS1_PORT_4A" Name="PORT_CODEC_RST_N"/>
-            
+
             <!-- I2C Slave ports -->
             <Port Location="XS1_PORT_1M" Name="PORT_I2C_SLAVE_SCL"/>
             <Port Location="XS1_PORT_1O" Name="PORT_I2C_SLAVE_SDA"/>
@@ -101,8 +101,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/>
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/examples/speech_recognition/XK_VOICE_L71.xn
+++ b/examples/speech_recognition/XK_VOICE_L71.xn
@@ -81,8 +81,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <!-- <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/> -->
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/test/asr/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/test/asr/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -77,12 +77,10 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="32768">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="32768">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <!-- <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/> -->
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/test/ffd_gpio/XCORE-AI-EXPLORER.xn
+++ b/test/ffd_gpio/XCORE-AI-EXPLORER.xn
@@ -100,12 +100,10 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/>
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/test/pipeline/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/test/pipeline/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="32768">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="32768">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/test/pipeline/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
+++ b/test/pipeline/bsp_config/XK_VOICE_L71/XK_VOICE_L71.xn
@@ -81,8 +81,6 @@
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>
-      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
-      <!-- <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/> -->
     </Device>
   </ExternalDevices>
   <JTAGChain>


### PR DESCRIPTION
These values are not required anymore starting from Tools 15.2.x. `xflash` will query the device flash via SFDP to get the correct values. 

The same changes have been made to the XN files used in the Tools.

Please note that the same changes should be done on all the .XN if we want to avoid the `xflash` warning:

`Site 0 reports warning: QE bit location override does not match SFDP response. Please check XN file or SPI-SPEC.`

Part of https://xmosjira.atlassian.net/browse/XVC-82